### PR TITLE
[readme] Arch needs the qt6-multimedia-gstreamer package for gstreamer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ and restart plasmashell `systemctl --user restart plasma-plasmashell.service` or
     **Arch**
 
     ```sh
-    sudo pacman -S qt6-multimedia gst-libav --needed
+    sudo pacman -S qt6-multimedia qt6-multimedia-gstreamer gst-libav --needed
     ```
 
     If you need extra codecs see https://wiki.archlinux.org/title/GStreamer


### PR DESCRIPTION
For the QT 6 gstreamer backend workaround to work the `qt6-multimedia-gstreamer` package is required.

PS: Personally I had a distorted image and `QT_DISABLE_HW_TEXTURES_CONVERSION=1` was enough to fix it, but gstreamer worked too.