### PR TITLE
New "Playback duration" settings

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -51,7 +51,7 @@
         5: never
     -->
     <entry name="BlurMode" type="Int">
-      <default>0</default>
+      <default>5</default>
     </entry>
     <entry name="BlurModeLocked" type="Int">
       <default>0</default>
@@ -96,6 +96,10 @@
     </entry>
     <entry name="CrossfadeDuration" type="Int">
       <default>1000</default>
+    </entry>
+    <entry name="PlaybackDuration" type="Int">
+      <label>Duration in seconds before switching to next video</label>
+      <default>0</default>
     </entry>
     <entry name="PlaybackRate" type="Double">
       <default>1</default>

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -62,6 +62,7 @@ Kirigami.FormLayout {
     property alias cfg_PlaybackRate: playbackRateSlider.value
     property alias cfg_Volume: volumeSlider.value
     property alias cfg_RandomMode: randomModeCheckbox.checked
+    property alias cfg_PlaybackDuration: playbackDurationSpinBox.value
     property int currentTab
     property bool showVideosList: false
     property var isLockScreenSettings: null
@@ -296,6 +297,23 @@ Kirigami.FormLayout {
         Kirigami.FormData.label: i18n("Play in random order:")
         id: randomModeCheckbox
         visible: currentTab === 1
+    }
+
+    RowLayout {
+        Kirigami.FormData.label: i18n("Playback duration:")
+        visible: currentTab === 1
+        SpinBox {
+            id: playbackDurationSpinBox
+            from: 0
+            to: 3600
+            value: cfg_PlaybackDuration
+            onValueChanged: {
+                cfg_PlaybackDuration = value
+            }
+        }
+        Label {
+            text: i18n("seconds (0 = disabled)")
+        }
     }
 
     RowLayout {


### PR DESCRIPTION
This changes introduces a new "Playback duration" setting that allows the user to change how long a video should be shown before it switches to the next video.
If the settings is "0", it is disabled.