### PR TITLE
!feat: mute audio based on window maximized/active/shown state

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -27,10 +27,6 @@
     <entry name="PauseMode" type="Int">
       <default>0</default>
     </entry>
-    <entry name="MuteAudio" type="Bool">
-      <label>Mute audio</label>
-      <default>true</default>
-    </entry>
     <entry name="PauseBatteryLevel" type="Int">
       <default>10</default>
     </entry>
@@ -51,7 +47,7 @@
         5: never
     -->
     <entry name="BlurMode" type="Int">
-      <default>0</default>
+      <default>5</default>
     </entry>
     <entry name="BlurRadius" type="Int">
       <default>32</default>
@@ -108,6 +104,17 @@
     </entry>
     <entry name="LastVideoPosition" type="Int">
       <default>0</default>
+    </entry>
+    <!-- Mute audio
+        0: when maximized or full-screen windows
+        1: when a visible window is active
+        2: when a window is visible
+        3: TODO application playing audio
+        4: never
+        5: always
+    -->
+    <entry name="MuteMode" type="Int">
+      <default>5</default>
     </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -115,6 +115,29 @@ WallpaperItem {
     property bool randomMode: main.configuration.RandomMode
     property int lastVideoPosition: main.configuration.LastVideoPosition
     property bool restoreLastPosition: true
+    property bool muteAudio: {
+        let mute = false
+        switch(main.configuration.MuteMode) {
+            case 0:
+                mute = windowModel.maximizedExists
+                break
+            case 1:
+                mute = windowModel.activeExists
+                break
+            case 2:
+                mute = windowModel.visibleExists
+                break
+            // case 3:
+            //  TODO other application playing audio
+            //  break
+            case 4:
+                mute = false
+                break
+            case 5:
+                mute = true
+        }
+        return mute
+    }
 
     function getVideos() {
         let videos = Utils.parseCompat(videoUrls).filter(video => video.enabled)
@@ -215,7 +238,7 @@ WallpaperItem {
 
         AudioOutput {
             id: audioOutput
-            muted: main.configuration.MuteAudio
+            muted: main.muteAudio
             volume: videoOutput.opacity * main.volume
         }
 
@@ -228,7 +251,7 @@ WallpaperItem {
 
         AudioOutput {
             id: audioOutput2
-            muted: main.configuration.MuteAudio
+            muted: main.muteAudio
             volume: volumeOutput2 * main.volume
             Behavior on volume {
                 NumberAnimation {


### PR DESCRIPTION
BREAKING CHANGE: if you had audio enabled you will have to re-enable it

refs: https://github.com/luisbocanegra/plasma-smart-video-wallpaper-reborn/issues/73