### PR TITLE
Fix MpvQt video positioning modes

### DIFF
--- a/package/contents/ui/VideoPlayerMpvQt.qml
+++ b/package/contents/ui/VideoPlayerMpvQt.qml
@@ -43,6 +43,7 @@ Item {
             } else {
                 mpv.setPropertyAsync(MpvProperties.Loops, "0");
             }
+            root.applyFillMode();
         }
         property int mediaStatus
         onFileLoaded: {
@@ -76,6 +77,28 @@ Item {
             mpv.setPropertyAsync(MpvProperties.Loops, "inf");
         } else {
             mpv.setPropertyAsync(MpvProperties.Loops, "0");
+        }
+    }
+
+    onFillModeChanged: {
+        console.error("VideoPlayerMpvQt -> fillMode:", root.fillMode);
+        applyFillMode();
+    }
+
+    function applyFillMode() {
+        if (root.fillMode === VideoOutput.Stretch) {
+            // Stretch: Force aspect ratio to match window
+            const aspectRatio = root.width / root.height;
+            mpv.setPropertyAsync(MpvProperties.VideoAspect, aspectRatio.toString());
+            mpv.setPropertyAsync(MpvProperties.Panscan, 0);
+        } else if (root.fillMode === VideoOutput.PreserveAspectFit) {
+            // Keep Proportions: Letterbox/pillarbox to fit
+            mpv.setPropertyAsync(MpvProperties.VideoAspect, "-1");
+            mpv.setPropertyAsync(MpvProperties.Panscan, 0);
+        } else if (root.fillMode === VideoOutput.PreserveAspectCrop) {
+            // Scaled and Cropped: Fill window by cropping
+            mpv.setPropertyAsync(MpvProperties.VideoAspect, "-1");
+            mpv.setPropertyAsync(MpvProperties.Panscan, 1.0);
         }
     }
 }

--- a/plugin/mpvproperties.h
+++ b/plugin/mpvproperties.h
@@ -52,6 +52,12 @@ public:
     Q_PROPERTY(QString Loops MEMBER Loops CONSTANT)
     const QString Loops{QStringLiteral("loop-file")};
 
+    Q_PROPERTY(QString Panscan MEMBER Panscan CONSTANT)
+    const QString Panscan{QStringLiteral("panscan")};
+
+    Q_PROPERTY(QString VideoAspect MEMBER VideoAspect CONSTANT)
+    const QString VideoAspect{QStringLiteral("video-aspect-override")};
+
 private:
     Q_DISABLE_COPY_MOVE(MpvProperties)
 };


### PR DESCRIPTION
When using the MpvQt backend, the "Positioning" dropdown options were not working. I noticed this while testing the MpvQt branch for my 16:9 HDR WebM PS5 captures on my 21:9 monitor, and there was pillarboxing, even though I had "Scaled and Cropped" selected.

I implemented proper fillMode handling by translating Qt's `VideoOutput.fillMode` enum to MPV-specific properties:

- **Stretch**: Sets `video-aspect-override` to window aspect ratio
- **Keep Proportions**: Sets `panscan=0` for letterboxing/pillarboxing
- **Scaled and Cropped**: Sets `panscan=1.0` to crop and fill