### PR TITLE
Fix looping in MpvQt implementation

### DIFF
--- a/package/contents/ui/FadePlayer.qml
+++ b/package/contents/ui/FadePlayer.qml
@@ -182,6 +182,17 @@ Item {
                 root.next(false, true);
             }
         }
+        onMediaStatusChanged: {
+            if (mediaStatus == MediaPlayer.EndOfMedia) {
+                if (root.crossfadeEnabled)
+                    return;
+                if (root.slideshowEnabled) {
+                    root.setNextSource();
+                }
+                videoPlayer2.playerSource = root.currentSource;
+                videoPlayer2.play();
+            }
+        }
         onPlayingChanged: {
             if (playing && root.debugEnabled) {
                 console.log("player2 playing");


### PR DESCRIPTION
This change implements logic to set the next source in slideshow mode and play the current source in videoPlayer2, as I found that when using MpvQt, a scenario could occur where no video was played (screen just black) likely after all videos had been played.

I tested by having two videos in the list, and couldn't reproduce after this fix was applied, but your mileage may vary!