### PR TITLE
Add session management for multiple users

### DIFF
--- a/package/contents/ui/SessionModel.qml
+++ b/package/contents/ui/SessionModel.qml
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2024 Luis Bocanegra <luisbocanegra17b@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  2.010-1301, USA.
+ */
+
+import QtQuick
+import org.kde.plasma.workspace.dbus as DBus
+
+Item {
+    id: root
+    property bool sessionIsActive: true
+    property bool checkSessionActivity: false
+    property string sessionPath: ""
+    property bool debugEnabled: false
+
+    Component.onCompleted: {
+        if (checkSessionActivity) {
+            getSessionPath();
+        }
+    }
+
+    onCheckSessionActivityChanged: {
+        if (checkSessionActivity && sessionPath === "") {
+            getSessionPath();
+        }
+    }
+
+    function getSessionPath() {
+        runCommand.run("loginctl show-user $USER -p Display --value");
+    }
+
+    RunCommand {
+        id: runCommand
+        onExited: (cmd, exitCode, exitStatus, stdout, stderr) => {
+            if (exitCode !== 0) {
+                if (debugEnabled) {
+                    console.error("SessionModel: Failed to get session:", stderr);
+                }
+                return;
+            }
+            const sessionId = stdout.trim();
+            if (sessionId) {
+                root.sessionPath = "/org/freedesktop/login1/session/" + sessionId;
+                getSessionActiveProperty();
+            } else if (debugEnabled) {
+                console.error("SessionModel: No session ID found");
+            }
+        }
+    }
+
+    function getSessionActiveProperty() {
+        if (sessionPath === "") return;
+
+        const getPropertyMsg = {
+            "service": "org.freedesktop.login1",
+            "path": root.sessionPath,
+            "iface": "org.freedesktop.DBus.Properties",
+            "member": "Get",
+            "arguments": ["org.freedesktop.login1.Session", "Active"],
+            "signature": null,
+            "inSignature": "ss"
+        };
+
+        const reply = DBus.SystemBus.asyncCall(getPropertyMsg);
+        reply.finished.connect(() => {
+            if (reply.value !== undefined && reply.value !== null) {
+                root.sessionIsActive = reply.value;
+            } else if (debugEnabled) {
+                console.error("SessionModel: Failed to get Active property");
+            }
+            reply.destroy();
+        });
+    }
+
+    function refresh() {
+        if (checkSessionActivity && sessionPath !== "") {
+            getSessionActiveProperty();
+        }
+    }
+
+    // Poll session state periodically (similar to ScreenModel.qml polling for screen state)
+    Timer {
+        id: sessionTimer
+        running: root.checkSessionActivity && root.sessionPath !== ""
+        repeat: true
+        interval: 1000
+        onTriggered: {
+            root.getSessionActiveProperty();
+        }
+    }
+}


### PR DESCRIPTION
This may be more of an edge-case, but as I have two separate users on my system, I noticed some performance concerns related to the following scenario:

- User A has the video wallpaper set for their lockscreen
- User A switches to User B
- User B checks `htop` and can see the `kscreenlocker_greet` process (attributed to User A's UID) using roughly 20% CPU, indicating that the video player, although not visible since User B is now active, is still playing in the background

This fix adds a check for the current session, and if it is not active, pauses the video so the CPU cycles are saved. In my particular case, since I use high quality videos (4K), it saves me 70 watts of energy by not playing the video frames in the background.

I hope it is an unobtrusive fix, but never any pressure to accept! BTW, thank you for accepting my other MpvQt Positioning PR, and for considering these other ones! I set this to merge to the `main` branch since it doesn't have any MPV-specific logic, or depend on that other branch.