### PR TITLE
Add random position feature for video playback

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -119,6 +119,10 @@
     <entry name="SlideshowEnabled" type="Bool">
       <default>true</default>
     </entry>
+    <entry name="RandomPosition" type="Bool">
+      <label>Start video from random position</label>
+      <default>false</default>
+    </entry>
     <!-- use MpvQt -->
     <entry name="UseMpvQt" type="Bool">
       <label>Use MpvQt instead of Qt Multimedia</label>

--- a/package/contents/ui/FadePlayer.qml
+++ b/package/contents/ui/FadePlayer.qml
@@ -17,6 +17,7 @@ Item {
     property bool multipleVideos: false
     property int lastVideoPosition: 0
     property bool restoreLastPosition: true
+    property bool randomPosition: false
     property bool debugEnabled: false
     property bool slideshowEnabled: true
     property bool disableCrossfade: false
@@ -125,6 +126,14 @@ Item {
             }
 
             if (mediaStatus == MediaPlayer.LoadedMedia && seekable) {
+                // Handle random position
+                if (root.randomPosition) {
+                    const randomPos = Math.floor(Math.random() * duration);
+                    videoPlayer1.setPosition(randomPos);
+                    return;
+                }
+
+                // Handle restore last position
                 if (!root.restoreLastPosition)
                     return;
                 if (root.lastVideoPosition < duration) {

--- a/package/contents/ui/VideoPlayer.qml
+++ b/package/contents/ui/VideoPlayer.qml
@@ -16,6 +16,7 @@ Item {
     readonly property bool seekable: playerLoader.item ? playerLoader.item.seekable : true
     readonly property int duration: playerLoader.item ? playerLoader.item.duration : 0
     property bool useMpvQt: false
+    property bool randomPosition: false
 
     function play() {
         if (playerLoader.item)
@@ -53,6 +54,9 @@ Item {
                 playerLoader.item.loops = root.loops;
                 playerLoader.item.fillMode = root.fillMode;
                 playerLoader.item.playbackRate = root.playbackRate;
+                if ('randomPosition' in playerLoader.item) {
+                    playerLoader.item.randomPosition = root.randomPosition;
+                }
                 playerLoader.item.mediaStatusChanged.connect(() => {
                     root.mediaStatus = playerLoader.item.mediaStatus;
                 });
@@ -88,5 +92,9 @@ Item {
     onLoopsChanged: {
         if (playerLoader.item)
             playerLoader.item.loops = root.loops;
+    }
+    onRandomPositionChanged: {
+        if (playerLoader.item && 'randomPosition' in playerLoader.item)
+            playerLoader.item.randomPosition = root.randomPosition;
     }
 }

--- a/package/contents/ui/VideoPlayer.qml
+++ b/package/contents/ui/VideoPlayer.qml
@@ -32,7 +32,12 @@ Item {
 
     function setPosition(newPosition) {
         if (playerLoader.item) {
-            playerLoader.item.position = newPosition;
+            // MpvQt has a setPosition() function, Qt player has writable position property
+            if (typeof playerLoader.item.setPosition === 'function') {
+                playerLoader.item.setPosition(newPosition);
+            } else {
+                playerLoader.item.position = newPosition;
+            }
         }
     }
 

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -63,6 +63,7 @@ Kirigami.FormLayout {
     property alias cfg_Volume: volumeSlider.value
     property alias cfg_RandomMode: randomModeCheckbox.checked
     property alias cfg_SlideshowEnabled: slideshowEnabledCheckbox.checked
+    property alias cfg_RandomPosition: randomPositionCheckbox.checked
     property alias cfg_UseMpvQt: useMpvQtCheckbox.checked
     property int currentTab
     property bool showVideosList: false
@@ -370,6 +371,17 @@ Kirigami.FormLayout {
         id: randomModeCheckbox
         Kirigami.FormData.label: i18n("Random order:")
         visible: currentTab === 1
+    }
+
+    RowLayout {
+        visible: currentTab === 1
+        Kirigami.FormData.label: i18n("Random position:")
+        CheckBox {
+            id: randomPositionCheckbox
+        }
+        Kirigami.ContextualHelpButton {
+            toolTipText: i18n("Start playing videos from a random position instead of from the beginning")
+        }
     }
 
     RowLayout {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -234,6 +234,7 @@ WallpaperItem {
             currentSource: main.currentSource
             muted: main.muteAudio
             lastVideoPosition: main.configuration.LastVideoPosition
+            randomPosition: main.configuration.RandomPosition
             onSetNextSource: {
                 main.nextVideo();
             }
@@ -343,6 +344,17 @@ WallpaperItem {
     }
 
     Component.onCompleted: {
+        // If random mode is enabled, select a random video on startup
+        if (main.configuration.RandomMode && videosConfig.length > 1) {
+            currentVideoIndex = Math.floor(Math.random() * videosConfig.length);
+            currentSource = videosConfig[currentVideoIndex];
+        }
+
+        // If random position is enabled, don't restore saved position
+        if (main.configuration.RandomPosition) {
+            restoreLastPosition = false;
+        }
+
         startTimer.start();
     }
 


### PR DESCRIPTION
When using this plugin on the lockscreen, I found that with MPV in particular, it would always play a video from the start (position: 0). This new features allows for a random starting point in the video, so that it makes the experience a little bit more dynamic, rather than always seeing the familiar start of whichever video was set to play.

There is also a timer of 100ms which allows for MPV to be ready before performing the skip to the random position. I troubleshot for a while but this is as good as I could get it, so (in MPV only) you may see a short 'blip' of the 'old' frame before it skips to the random one. Still barely noticeable but keeps the experience fresh.

The Qt video backend did remember the video position and resume without issue, but MPV works differently, and always started at position: 0. I felt that even Qt video backend users could still take advantage of this if they wanted, but as it has MPV-specific logic, I am pointing it back to your `mpvqt-plugin` branch.

As with my other PRs, absolutely no worries if it's not a feature you wanted to implement!
