### PR TITLE
Another try at a "Play for a duration" setting

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -116,8 +116,14 @@
     <entry name="MuteMode" type="Int">
       <default>5</default>
     </entry>
-    <entry name="SlideshowEnabled" type="Bool">
-      <default>true</default>
+    <entry name="ChangeWallpaperMode" type="Int">
+      <default>1</default>
+    </entry>
+    <entry name="ChangeWallpaperTimerMinutes" type="Int">
+      <default>10</default>
+    </entry>
+    <entry name="ChangeWallpaperTimerHours" type="Int">
+      <default>0</default>
     </entry>
   </group>
 </kcfg>

--- a/package/contents/ui/FadePlayer.qml
+++ b/package/contents/ui/FadePlayer.qml
@@ -4,6 +4,7 @@ import QtMultimedia
 import org.kde.plasma.components as PlasmaComponents
 import org.kde.kirigami as Kirigami
 import "code/utils.js" as Utils
+import "code/enum.js" as Enum
 
 Item {
     id: root
@@ -18,19 +19,31 @@ Item {
     property int lastVideoPosition: 0
     property bool restoreLastPosition: true
     property bool debugEnabled: false
-    property bool slideshowEnabled: true
-
-    property bool disableCrossfade: false
-    property int position
+    property int changeWallpaperMode: Enum.ChangeWallpaperMode.Slideshow
+    property int changeWallpaperTimerMinutes: 10
+    property int changeWallpaperTimerHours: 0
+    property int changeWallpaperTimerTime: (changeWallpaperTimerHours*60+changeWallpaperTimerMinutes)*60*1000
 
     // Crossfade must not be longer than the shortest video or the fade becomes glitchy
     // we don't know the length until a video gets played, so the crossfade duration
     // will decrease below the configured duration if needed as videos get played
-    property int crossfadeMinDuration: parseInt(Math.max(Math.min(videoPlayer1.actualDuration, videoPlayer2.actualDuration) / 3, 1))
-    property int crossfadeDuration: disableCrossfade ? 0 : Math.min(root.targetCrossfadeDuration, crossfadeMinDuration)
+    // Split the crossfade duration between the two videos. If either video is too short,
+    // reduce only it's part of the crossfade duration accordingly
+    property int crossfadeMinDurationLast: Math.min(root.targetCrossfadeDuration/2, otherPlayer.actualDuration/3);
+    property int crossfadeMinDurationCurrent: Math.min(root.targetCrossfadeDuration/2, player.actualDuration/3);
+    property int crossfadeDuration: {
+        if(!root.crossfadeEnabled){
+            return 0;
+        }else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.OnATimer){
+            return Math.min(root.targetCrossfadeDuration, changeWallpaperTimerTime/3*2);
+        } else {
+            return crossfadeMinDurationLast + crossfadeMinDurationCurrent;
+        }
+    }
 
     property bool primaryPlayer: true
     property VideoPlayer player: primaryPlayer ? videoPlayer1 : videoPlayer2
+    property VideoPlayer otherPlayer: primaryPlayer ? videoPlayer2 : videoPlayer1
 
     function play() {
         player.play();
@@ -41,34 +54,49 @@ Item {
     function stop() {
         player.stop();
     }
-    function next(switchSource, fade) {
+    function next(switchSource) {
         if (switchSource) {
             setNextSource();
         }
-        if (fade) {
-            if (primaryPlayer) {
-                videoPlayer1.opacity = 0;
-                videoPlayer2.playerSource = root.currentSource;
-                videoPlayer2.play();
-                root.primaryPlayer = false;
-            } else {
-                videoPlayer1.opacity = 1;
-                videoPlayer1.playerSource = root.currentSource;
-                videoPlayer1.play();
-                root.primaryPlayer = true;
-            }
+        if (primaryPlayer) {
+            videoPlayer2.playerSource = root.currentSource;
+            videoPlayer2.play();
+            root.primaryPlayer = false;
+            videoPlayer1.opacity = 0;
+
         } else {
-            primaryPlayer = true;
-            root.disableCrossfade = true;
-            videoPlayer2.stop();
-            videoPlayer1.stop();
             videoPlayer1.playerSource = root.currentSource;
-            videoPlayer1.opacity = 1;
             videoPlayer1.play();
-            root.disableCrossfade = false;
+            root.primaryPlayer = true;
+            videoPlayer1.opacity = 1;
+        }
+
+        if(root.changeWallpaperMode === Enum.ChangeWallpaperMode.OnATimer){
+            changeTimer.restart();
         }
     }
     signal setNextSource
+
+    Timer{
+        id: changeTimer
+        running: root.changeWallpaperMode === Enum.ChangeWallpaperMode.OnATimer
+        interval: !running ? 0 : changeWallpaperTimerTime - (root.crossfadeEnabled ? root.crossfadeMinDurationCurrent : 0)
+        repeat: true
+        onTriggered: {
+            if(root.debugEnabled){
+                console.log("Timer triggered, changing wallpaper");
+            }
+            root.next(true);
+        }
+        onIntervalChanged: {
+            if(running){
+                if(root.debugEnabled){
+                    console.log("Timer started. Interval:", interval);
+                }
+                changeTimer.restart();
+            }
+        }
+    }
 
     VideoPlayer {
         id: videoPlayer1
@@ -84,13 +112,12 @@ Item {
         opacity: 1
         fillMode: root.fillMode
         loops: {
-            if (!root.slideshowEnabled) {
+            if(!root.multipleVideos)
                 return MediaPlayer.Infinite;
-            }
-            if (root.multipleVideos || root.crossfadeEnabled) {
+            else if(root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow)
                 return 1;
-            }
-            return MediaPlayer.Infinite;
+            else // all other (future) modes
+                return MediaPlayer.Infinite;
         }
         onPositionChanged: {
             if (!root.primaryPlayer) {
@@ -100,27 +127,25 @@ Item {
                 root.lastVideoPosition = position;
             }
 
-            if ((position / playbackRate) > (actualDuration - root.crossfadeDuration)) {
-                if (root.crossfadeEnabled) {
-                    if (root.slideshowEnabled) {
-                        root.setNextSource();
+            if (root.crossfadeEnabled) {
+                if ((position / playbackRate) > (actualDuration - root.crossfadeMinDurationCurrent)) {
+                    if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                        root.next(true);
                     }
-                    if (root.debugEnabled) {
-                        console.log("player1 fading out");
+                    else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Never) {
+                        root.next(false);
                     }
-                    root.next(false, true);
                 }
             }
         }
         onMediaStatusChanged: {
             if (mediaStatus == MediaPlayer.EndOfMedia) {
-                if (root.crossfadeEnabled)
+                if (root.crossfadeEnabled) {
                     return;
-                if (root.slideshowEnabled) {
-                    root.setNextSource();
                 }
-                videoPlayer1.playerSource = root.currentSource;
-                videoPlayer1.play();
+                else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                    root.next(true);
+                }
             }
 
             if (mediaStatus == MediaPlayer.LoadedMedia && seekable) {
@@ -133,14 +158,26 @@ Item {
                 root.restoreLastPosition = false;
             }
         }
+        onLoopsChanged:{
+            if(primaryPlayer){
+                // needed to correctly update player with new loops value
+                let pos = videoPlayer1.position;
+                videoPlayer1.stop();
+                videoPlayer1.play();
+                videoPlayer1.position = pos;
+            }
+        }
         onPlayingChanged: {
             if (playing) {
-                if (videoPlayer1.opacity === 0) {
-                    opacity = 1;
-                }
                 if (root.debugEnabled) {
                     console.log("Player 1 playing");
                 }
+            }
+        }
+        onOpacityChanged: {
+            if(opacity === 0 || opacity === 1) {
+                // Reset other player source to empty to free resources
+                otherPlayer.playerSource = Utils.createVideo("");
             }
         }
         Behavior on opacity {
@@ -163,26 +200,55 @@ Item {
         muted: root.muted
         z: 1
         fillMode: root.fillMode
-        loops: 1
+        loops: {
+            if(!root.multipleVideos)
+                return MediaPlayer.Infinite;
+            else if(root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow)
+                return 1;
+            else // all other (future) modes
+                return MediaPlayer.Infinite;
+        }
         onPositionChanged: {
             if (root.primaryPlayer) {
                 return;
             }
             root.lastVideoPosition = position;
 
-            if ((position / playbackRate) > (actualDuration - root.crossfadeDuration)) {
-                if (root.debugEnabled) {
-                    console.log("player1 fading in");
+           if (root.crossfadeEnabled) {
+                if ((position / playbackRate) > (actualDuration - root.crossfadeMinDurationCurrent)) {
+                    if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                        root.next(true);
+                    }
+                    else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Never) {
+                        root.next(false);
+                    }
                 }
-                if (root.slideshowEnabled) {
-                    root.setNextSource();
+            }
+        }
+        onMediaStatusChanged: {
+            if (mediaStatus == MediaPlayer.EndOfMedia) {
+                if (root.crossfadeEnabled) {
+                    return;
                 }
-                root.next(false, true);
+                else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                    root.next(true);
+                }
+            }
+        }
+        onLoopsChanged:{
+            if(!primaryPlayer){
+                // needed to correctly update player with new loops value
+                let pos = videoPlayer2.position;
+                videoPlayer2.stop();
+                videoPlayer2.play();
+                videoPlayer2.position = pos;
             }
         }
         onPlayingChanged: {
-            if (playing && root.debugEnabled) {
-                console.log("player2 playing");
+            if (playing) {
+                if (root.debugEnabled) {
+                    console.log("Player 2 playing");
+                }
             }
         }
     }
@@ -202,10 +268,13 @@ Item {
                     text: root.player.source
                 }
                 PlasmaComponents.Label {
-                    text: "slideshow " + root.slideshowEnabled
+                    text: "changeWallpaperMode " + root.changeWallpaperMode
                 }
                 PlasmaComponents.Label {
                     text: "crossfade " + root.crossfadeEnabled
+                }
+                PlasmaComponents.Label {
+                    text: "crossfadeDuration " + root.crossfadeDuration+ " ("+root.crossfadeMinDurationLast+", "+root.crossfadeMinDurationCurrent+")"
                 }
                 PlasmaComponents.Label {
                     text: "multipleVideos " + root.multipleVideos

--- a/package/contents/ui/code/enum.js
+++ b/package/contents/ui/code/enum.js
@@ -9,3 +9,10 @@ const MuteOverride = {
   Unmute: 1,
   Default: 2,
 };
+
+// Keep this list in sync with config.qml 
+const ChangeWallpaperMode = {
+  Never: 0,
+  Slideshow: 1,
+  OnATimer: 2,
+};

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -27,6 +27,7 @@ import org.kde.kirigami as Kirigami
 import org.kde.kquickcontrols 2.0 as KQuickControls
 import org.kde.kirigami as Kirigami
 import "code/utils.js" as Utils
+import "code/enum.js" as Enum
 import "components" as Components
 
 Kirigami.FormLayout {
@@ -60,7 +61,9 @@ Kirigami.FormLayout {
     property alias cfg_PlaybackRate: playbackRateSlider.value
     property alias cfg_Volume: volumeSlider.value
     property alias cfg_RandomMode: randomModeCheckbox.checked
-    property alias cfg_SlideshowEnabled: slideshowEnabledCheckbox.checked
+    property alias cfg_ChangeWallpaperMode: changeWallpaperModeComboBox.currentIndex
+    property alias cfg_ChangeWallpaperTimerMinutes: changeWallpaperTimerMinutesSpinBox.value
+    property alias cfg_ChangeWallpaperTimerHours: changeWallpaperTimerHoursSpinBox.value
     property int currentTab
     property bool showVideosList: false
     property var isLockScreenSettings: null
@@ -319,12 +322,51 @@ Kirigami.FormLayout {
 
     RowLayout {
         visible: currentTab === 1
-        Kirigami.FormData.label: i18n("Slideshow:")
-        CheckBox {
-            id: slideshowEnabledCheckbox
+        Kirigami.FormData.label: i18n("Change Wallpaper:")
+        ComboBox{
+            id: changeWallpaperModeComboBox
+            // Keep this list in sync with enum.js          
+            model: [
+                {
+                'label': i18n("Never")
+                },
+                {
+                'label': i18n("Slideshow")
+                },
+                {
+                'label': i18n("On a Timer")
+                }
+            ]
+            textRole: "label"
+            onCurrentIndexChanged: {
+                cfg_ChangeWallpaperMode = currentIndex;
+            }
+            currentIndex: cfg_ChangeWallpaperMode
         }
         Kirigami.ContextualHelpButton {
-            toolTipText: i18n("Automatically play next video when the current one ends. Disable to do it manually using <strong>Next Video</strong> from the Desktop right click menu.")
+            toolTipText: i18n("Automatically play the next video using the selected strategy. You can also change the wallpaper manually using <strong>Next Video</strong> from the Desktop right click menu.")
+        }
+    }
+
+    RowLayout {
+        visible: currentTab === 1 && changeWallpaperModeComboBox.currentIndex === Enum.ChangeWallpaperMode.OnATimer
+        Label {
+            text: i18n("Hours:")
+        }
+        SpinBox{
+            id: changeWallpaperTimerHoursSpinBox
+            from: 0
+            to: 12
+            stepSize: 1
+        }
+        Label {
+            text: i18n("Minutes:")
+        }
+        SpinBox{
+            id: changeWallpaperTimerMinutesSpinBox
+            from: changeWallpaperTimerHoursSpinBox.value > 0 ? 0 : 1
+            to: 59
+            stepSize: 1
         }
     }
 

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -120,7 +120,9 @@ WallpaperItem {
     property bool randomMode: main.configuration.RandomMode
     property int lastVideoPosition: main.configuration.LastVideoPosition
     property bool restoreLastPosition: true
-    property bool slideshowEnabled: main.configuration.SlideshowEnabled
+    property int changeWallpaperMode: main.configuration.ChangeWallpaperMode
+    property int changeWallpaperTimerMinutes: main.configuration.ChangeWallpaperTimerMinutes
+    property int changeWallpaperTimerHours: main.configuration.ChangeWallpaperTimerHours
     property bool muteAudio: {
         if (muteOverride === Enum.MuteOverride.Mute) {
             return true;
@@ -241,7 +243,9 @@ WallpaperItem {
             multipleVideos: main.videosConfig.length > 1
             targetCrossfadeDuration: main.configuration.CrossfadeDuration
             debugEnabled: main.debugEnabled
-            slideshowEnabled: main.slideshowEnabled
+            changeWallpaperMode: main.changeWallpaperMode
+            changeWallpaperTimerMinutes: main.changeWallpaperTimerMinutes
+            changeWallpaperTimerHours: main.changeWallpaperTimerHours
             fillMode: main.configuration.FillMode
             volume: main.volume
             playbackRate: main.playbackRate
@@ -377,7 +381,7 @@ WallpaperItem {
             text: i18n("Next Video")
             icon.name: "media-skip-forward"
             onTriggered: {
-                player.next(true, false);
+                player.next(true);
             }
             visible: player.multipleVideos
         },


### PR DESCRIPTION
This PR:
- replaces the "slideshow enabled"-CheckBox with a ComboBox to allow more extensibility, similar to how Wallpaper Engine has implemented it. (Later on more modes could be "time of day" etc.)
- introduces a new "Change Wallpaper"-option "On a timer", where the user can specify a duration for which the current wallpaper loops. When this duration is over, it transitions to the next wallpaper according to the transition settings (random/crossfade).
- reworks the crossfade mechanic  to make it work with the new setting. Now both video players are always used for transitions.

I tested with 1-3 videos (GIFs), where one is shorter than 1 second, the others longer. 
If you notice any issues, please tell me.

On another note: Is there a reason "gif" is not in the list of searchable file types? At least the GIFs I used worked perfectly fine, so they should be searchable more easily. I wasn't sure whether I should make a separate PR for that. If you allow it, I would add that change to this PR.