### PR TITLE
Fix: Lockscreen crash when using gstreamer

### DIFF
--- a/package/contents/ui/FadePlayer.qml
+++ b/package/contents/ui/FadePlayer.qml
@@ -8,7 +8,7 @@ import "code/enum.js" as Enum
 
 Item {
     id: root
-    property var currentSource
+    property var currentSource: Utils.createVideo("")
     property real volume: 1.0
     property bool muted: true
     property real playbackRate: 1
@@ -102,7 +102,7 @@ Item {
         id: videoPlayer1
         objectName: "1"
         anchors.fill: parent
-        property var playerSource: Utils.createVideo("")
+        property var playerSource: root.currentSource
         property int actualDuration: duration / playbackRate
         playbackRate: playerSource.playbackRate || root.playbackRate
         source: playerSource.filename ?? ""

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -241,7 +241,6 @@ WallpaperItem {
         FadePlayer {
             id: player
             anchors.fill: parent
-            currentSource: main.currentSource
             muted: main.muteAudio
             lastVideoPosition: main.configuration.LastVideoPosition
             onSetNextSource: {
@@ -356,7 +355,11 @@ WallpaperItem {
 
     Component.onCompleted: {
         startTimer.start();
-        Qt.callLater(() => player.next(false));
+        Qt.callLater(() => {
+            player.currentSource = Qt.binding(() => {
+                return main.currentSource;
+            });
+        });
     }
 
     function save() {


### PR DESCRIPTION
Possible fix for https://github.com/luisbocanegra/plasma-smart-video-wallpaper-reborn/issues/171

The issue seems to be that the FadePlayer was started too soon after instantiation. I guess previously the lockscreen didn't crash because the timing luckily just worked out.

This fixes the issue on my OpenSUSE VM with KDE and gstreamer backend. 

Using `kscreenlocker_greet --testing` it takes up to a few seconds to fully terminate the process after entering the password. When a crossfade happened, then a message `"Could not finish change state of "playbin3" ASYNC PAUSED PAUSED"` appears. But, at least for me, this does not cause issues with the actual lockscreen, so it does not seem to be a big problem.

Please test before merging.