### PR TITLE
fix: disabled videos continue playing after pause/play event

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -76,7 +76,7 @@ WallpaperItem {
         return play;
     }
     property bool playing: {
-        return (shouldPlay && !batteryPausesVideo && !screenLocked && !screenIsOff && !effectPauseVideo) || effectPlayVideo;
+        return ((shouldPlay && !batteryPausesVideo && !screenLocked && !screenIsOff && !effectPauseVideo) || effectPlayVideo) && videosConfig.length !== 0;
     }
     property bool shouldBlur: {
         if (videosConfig.length == 0) {


### PR DESCRIPTION
refs: https://github.com/luisbocanegra/plasma-smart-video-wallpaper-reborn/issues/129