### PR TITLE
WIP! feat: add feature prebufferNextVideo

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -93,6 +93,10 @@
     <entry name="CrossfadeDuration" type="Int">
       <default>1000</default>
     </entry>
+    <entry name="PrebufferNextVideo" type="Bool">
+      <label>Preload next video into memory to reduce black-frame transitions</label>
+      <default>false</default>
+    </entry>
     <entry name="PlaybackRate" type="Double">
       <default>1</default>
     </entry>

--- a/package/contents/ui/FadePlayer.qml
+++ b/package/contents/ui/FadePlayer.qml
@@ -27,55 +27,798 @@ Item {
     property real alternativePlaybackRateGlobal: 0.5
     property bool useAlternativePlaybackRate: false
 
-    // Crossfade must not be longer than the shortest video or the fade becomes glitchy
-    // we don't know the length until a video gets played, so the crossfade duration
-    // will decrease below the configured duration if needed as videos get played
-    // Split the crossfade duration between the two videos. If either video is too short,
-    // reduce only it's part of the crossfade duration accordingly
-    property int crossfadeMinDurationLast: Math.min(root.targetCrossfadeDuration / 2, otherPlayer.actualDuration / 3)
-    property int crossfadeMinDurationCurrent: Math.min(root.targetCrossfadeDuration / 2, player.actualDuration / 3)
+    property bool prebufferNextVideo: true
+    property var nextSource: Utils.createVideo("")
+
+    property int crossfadeMinDurationLast: {
+        const d = Number(otherPlayer.actualDuration);
+        const safeDuration = Number.isFinite(d) ? Math.max(0, d) : 0;
+        return Math.min(root.targetCrossfadeDuration / 2, safeDuration / 3);
+    }
+    property int crossfadeMinDurationCurrent: {
+        const d = Number(player.actualDuration);
+        const safeDuration = Number.isFinite(d) ? Math.max(0, d) : 0;
+        return Math.min(root.targetCrossfadeDuration / 2, safeDuration / 3);
+    }
     property int crossfadeDuration: {
+        const safeLast = Number.isFinite(crossfadeMinDurationLast) ? Math.max(0, crossfadeMinDurationLast) : 0;
+        const safeCurrent = Number.isFinite(crossfadeMinDurationCurrent) ? Math.max(0, crossfadeMinDurationCurrent) : 0;
         if (!root.crossfadeEnabled) {
             return 0;
         } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.OnATimer) {
             return Math.min(root.targetCrossfadeDuration, changeWallpaperTimerMs / 3 * 2);
         } else {
-            return crossfadeMinDurationLast + crossfadeMinDurationCurrent;
+            return safeLast + safeCurrent;
         }
     }
 
+    readonly property int stateIdle: 0
+    readonly property int statePrebuffering: 1
+    readonly property int statePendingSwap: 2
+    readonly property int stateFading: 3
+
+    property int transitionState: root.stateIdle
+    readonly property string transitionStateName: root.stateName(root.transitionState)
+    readonly property bool transitionBusy: root.transitionState === root.statePendingSwap || root.transitionState === root.stateFading
+
     property bool primaryPlayer: true
+    property string pendingTargetFilename: ""
+    property bool pendingAdvancePlaylist: false
+    property real pendingSwitchStartMs: 0
+    property bool holdActiveTailFrame: false
+    property bool fadeVisualPending: false
+    property bool fadeAdvanceSourcePending: false
+    property bool fadeIncomingIsPlayer1: false
+    property int fadeResumeBaselinePosition: 0
+    property int fadeResumeMinDeltaMs: 80
+    property int fadeResumeTimeoutMs: 220
+    property real fadeResumeDeadlineMs: 0
+    property int prebufferWarmupMinMs: 90
+
+    property int prebufferGeneration: 0
+    property int activePrebufferGeneration: 0
+    property string lastFailedTargetFilename: ""
+    property int maxPrebufferRetries: 1
+    property int timeoutPrebufferRetries: 2
+    property int prebufferRetryExtraTimeoutMs: 900
+    property int prebufferStallTimeoutMs: Math.max(2200, root.safeCrossfadeDuration() * 4 + 1200)
+    property int pendingSwitchTimeoutMs: Math.max(2500, root.prebufferStallTimeoutMs + root.safeCrossfadeDuration())
+    property int holdTailLeadMs: Math.max(80, Math.min(260, root.safeCrossfadeDuration() / 2 + 80))
+
     property VideoPlayer player: primaryPlayer ? videoPlayer1 : videoPlayer2
     property VideoPlayer otherPlayer: primaryPlayer ? videoPlayer2 : videoPlayer1
+
     readonly property alias player1: videoPlayer1
     readonly property alias player2: videoPlayer2
+
+    signal setNextSource
+    signal requestNextCandidate(string failedFilename)
+
+    function stateName(value) {
+        switch (value) {
+        case root.stateIdle:
+            return "Idle";
+        case root.statePrebuffering:
+            return "Prebuffering";
+        case root.statePendingSwap:
+            return "PendingSwap";
+        case root.stateFading:
+            return "Fading";
+        default:
+            return "Unknown";
+        }
+    }
+
+    function shortFilename(filename) {
+        if (!filename) {
+            return "<none>";
+        }
+        const parts = filename.split("/");
+        return parts.length === 0 ? filename : parts[parts.length - 1];
+    }
+
+    function sourceFilename(videoSource) {
+        return videoSource && videoSource.filename ? videoSource.filename : "";
+    }
+
+    function logDebug(channel, message) {
+        if (root.debugEnabled) {
+            console.log(`[FadePlayer][${channel}] ${message}`);
+        }
+    }
 
     function play() {
         player.play();
     }
+
     function pause() {
         player.pause();
     }
+
     function stop() {
         player.stop();
     }
-    function next(switchSource, forceSwitch) {
-        if ((switchSource && !currentSource.loop) || forceSwitch) {
-            setNextSource();
+
+    function safeCrossfadeDuration() {
+        return Number.isFinite(root.crossfadeDuration) ? Math.max(0, root.crossfadeDuration) : 0;
+    }
+
+    function refreshWatchdog() {
+        prebufferWatchdog.running = root.transitionState === root.statePendingSwap
+                || root.fadeVisualPending
+                || videoPlayer1.prebufferPending
+                || videoPlayer2.prebufferPending;
+    }
+
+    function setTransitionState(nextState, reason) {
+        if (root.transitionState === nextState) {
+            return;
         }
-        if (primaryPlayer) {
-            videoPlayer2.playerSource = root.currentSource;
-            videoPlayer2.play();
-            root.primaryPlayer = false;
-            videoPlayer1.opacity = 0;
-        } else {
-            videoPlayer1.playerSource = root.currentSource;
-            videoPlayer1.play();
-            root.primaryPlayer = true;
-            videoPlayer1.opacity = 1;
+        root.logDebug("transition", `${root.stateName(root.transitionState)} -> ${root.stateName(nextState)} (${reason})`);
+        root.transitionState = nextState;
+        refreshWatchdog();
+    }
+
+    function clearPrebufferState(target, reason) {
+        const hadState = target.prebufferPending || target.prebufferReady || target.prebufferTargetFilename !== "";
+        if (hadState) {
+            root.logDebug("prebuffer", `cancel player=${target.objectName} target=${root.shortFilename(target.prebufferTargetFilename)} reason=${reason}`);
+        }
+        target.prebufferPending = false;
+        target.prebufferReady = false;
+        target.prebufferTargetFilename = "";
+        target.prebufferGeneration = 0;
+        target.prebufferStartMs = 0;
+        target.prebufferReadyPosition = 0;
+        target.prebufferRetryCount = 0;
+        refreshWatchdog();
+    }
+
+    function assignPlayerSource(target, source, reason) {
+        const filename = root.sourceFilename(source);
+        if (target.playerSource.filename === filename) {
+            return;
+        }
+        if (filename === "" && root.prebufferNextVideo
+                && reason !== "non-prebuffer-clear"
+                && reason !== "prebuffer-reset") {
+            return;
+        }
+        root.logDebug("source", `assign player=${target.objectName} source=${root.shortFilename(filename)} reason=${reason}`);
+        target.playerSource = source;
+    }
+
+    function syncActivePlayerSource(force) {
+        const filename = root.sourceFilename(root.currentSource);
+        if (!filename) {
+            return;
+        }
+        if (root.transitionState === root.statePendingSwap || root.transitionState === root.stateFading) {
+            return;
+        }
+        const active = root.player;
+        if (force
+                || !active.playerSource.filename
+                || active.mediaStatus === MediaPlayer.NoMedia
+                || active.mediaStatus === MediaPlayer.InvalidMedia) {
+            clearPrebufferState(active, "active-source-sync");
+            assignPlayerSource(active, root.currentSource, "active-source-sync");
         }
     }
-    signal setNextSource
+
+    function isPlayerReadyFor(target, targetFilename) {
+        return !!targetFilename
+                && target.playerSource.filename === targetFilename
+                && target.prebufferTargetFilename === targetFilename
+                && !target.prebufferPending
+                && target.prebufferReady;
+    }
+
+    function isInactivePrebufferReadyFor(targetFilename) {
+        return isPlayerReadyFor(root.otherPlayer, targetFilename);
+    }
+
+    function ensurePrebufferEventCurrent(target, reason) {
+        if (!target.prebufferPending) {
+            return false;
+        }
+
+        if (target.prebufferGeneration === 0 || target.prebufferGeneration !== root.activePrebufferGeneration) {
+            root.logDebug("prebuffer", `stale-event-ignored player=${target.objectName} reason=${reason}`);
+            clearPrebufferState(target, "stale-generation");
+            return false;
+        }
+
+        if (target.prebufferTargetFilename === "" || target.playerSource.filename !== target.prebufferTargetFilename) {
+            root.logDebug("prebuffer", `stale-event-ignored player=${target.objectName} source=${root.shortFilename(target.playerSource.filename)} target=${root.shortFilename(target.prebufferTargetFilename)} reason=${reason}`);
+            clearPrebufferState(target, "stale-source");
+            return false;
+        }
+
+        return true;
+    }
+
+    function releaseTailHold(resumePlayback) {
+        if (!root.holdActiveTailFrame) {
+            return;
+        }
+        const active = root.player;
+        root.holdActiveTailFrame = false;
+        if (resumePlayback) {
+            if (!active.playing) {
+                active.play();
+            }
+        }
+    }
+
+    function holdActiveFrameIfNearTail(activePlayer) {
+        if (root.transitionState !== root.statePendingSwap || root.holdActiveTailFrame || !activePlayer.duration) {
+            return;
+        }
+        const holdAt = Math.max(0, activePlayer.duration - root.holdTailLeadMs);
+        if (activePlayer.position >= holdAt) {
+            if (activePlayer.seekable) {
+                activePlayer.position = Math.max(0, activePlayer.duration - 16);
+            }
+            activePlayer.pause();
+            root.holdActiveTailFrame = true;
+            root.logDebug("transition", `hold-tail player=${activePlayer.objectName} position=${activePlayer.position} duration=${activePlayer.duration}`);
+        }
+    }
+
+    function resolveVideoSourceForFilename(filename, fallbackSource) {
+        if (!filename) {
+            return Utils.createVideo("");
+        }
+        if (root.sourceFilename(root.nextSource) === filename) {
+            return root.nextSource;
+        }
+        if (root.sourceFilename(root.currentSource) === filename) {
+            return root.currentSource;
+        }
+        if (root.sourceFilename(fallbackSource) === filename) {
+            return fallbackSource;
+        }
+        return Utils.createVideo(filename);
+    }
+
+    function beginPrebufferOnPlayer(target, source, reason, retryCount) {
+        const targetFilename = root.sourceFilename(source);
+        if (!targetFilename) {
+            return false;
+        }
+
+        root.prebufferGeneration += 1;
+        const generation = root.prebufferGeneration;
+        root.activePrebufferGeneration = generation;
+
+        clearPrebufferState(target, "new-request");
+
+        // Reusing the same filename can leave the decoder at tail/end state.
+        // Force reload for deterministic prebuffer warmup.
+        if (target.playerSource.filename === targetFilename) {
+            root.logDebug("prebuffer", `force-reload same-source player=${target.objectName} target=${root.shortFilename(targetFilename)}`);
+            target.stop();
+            assignPlayerSource(target, Utils.createVideo(""), "prebuffer-reset");
+        }
+        assignPlayerSource(target, source, `prebuffer-gen-${generation}`);
+
+        target.prebufferPending = true;
+        target.prebufferReady = false;
+        target.prebufferTargetFilename = targetFilename;
+        target.prebufferGeneration = generation;
+        target.prebufferStartMs = Date.now();
+        target.prebufferReadyPosition = 0;
+        target.prebufferRetryCount = retryCount;
+
+        if (target.seekable) {
+            target.position = 0;
+        }
+        target.play();
+        root.logDebug("prebuffer", `start player=${target.objectName} target=${root.shortFilename(targetFilename)} reason=${reason}`);
+
+        if (root.transitionState === root.stateIdle) {
+            setTransitionState(root.statePrebuffering, "prebuffer-start");
+        }
+
+        refreshWatchdog();
+        return true;
+    }
+
+    function retryLimitForReason(reason) {
+        if (reason === "invalid-media") {
+            return 0;
+        }
+        if (reason === "timeout") {
+            return Math.max(root.maxPrebufferRetries, root.timeoutPrebufferRetries);
+        }
+        return root.maxPrebufferRetries;
+    }
+
+    function startPrebufferForInactive(reason) {
+        if (!root.prebufferNextVideo || root.transitionState === root.stateFading) {
+            return;
+        }
+
+        const targetFilename = root.sourceFilename(root.nextSource);
+        if (!targetFilename) {
+            if (root.transitionState === root.statePrebuffering) {
+                setTransitionState(root.stateIdle, "empty-prebuffer-target");
+            }
+            refreshWatchdog();
+            return;
+        }
+
+        const inactive = root.otherPlayer;
+        if (isPlayerReadyFor(inactive, targetFilename)) {
+            if (root.transitionState === root.statePrebuffering) {
+                setTransitionState(root.stateIdle, "already-ready");
+            }
+            refreshWatchdog();
+            return;
+        }
+
+        if (inactive.prebufferPending
+                && inactive.prebufferTargetFilename === targetFilename
+                && inactive.playerSource.filename === targetFilename) {
+            root.logDebug("prebuffer", `in-flight player=${inactive.objectName} target=${root.shortFilename(targetFilename)} reason=${reason}`);
+            refreshWatchdog();
+            return;
+        }
+
+        beginPrebufferOnPlayer(inactive, root.nextSource, reason, 0);
+    }
+
+    function retryPrebufferTarget(target, reason) {
+        const targetFilename = target.prebufferTargetFilename;
+        if (!targetFilename || !root.prebufferNextVideo || root.transitionState === root.stateFading) {
+            return false;
+        }
+
+        const currentRetry = target.prebufferRetryCount || 0;
+        const retryLimit = root.retryLimitForReason(reason);
+        if (currentRetry >= retryLimit) {
+            return false;
+        }
+
+        const retrySource = resolveVideoSourceForFilename(targetFilename, target.playerSource);
+        const nextRetry = currentRetry + 1;
+        root.logDebug("prebuffer", `retry player=${target.objectName} target=${root.shortFilename(targetFilename)} reason=${reason}`);
+        return beginPrebufferOnPlayer(target, retrySource, `retry-${reason}`, nextRetry);
+    }
+
+    function markPrebufferReady(target, reason) {
+        if (!ensurePrebufferEventCurrent(target, reason)) {
+            return;
+        }
+
+        const readyFilename = target.prebufferTargetFilename;
+        const readyPosition = target.position;
+        target.pause();
+        target.prebufferPending = false;
+        target.prebufferReady = true;
+        target.prebufferReadyPosition = readyPosition;
+        target.prebufferStartMs = 0;
+
+        root.logDebug("prebuffer", `first-frame-ready player=${target.objectName} target=${root.shortFilename(readyFilename)} pos=${readyPosition}`);
+
+        if (root.transitionState === root.statePrebuffering) {
+            setTransitionState(root.stateIdle, "prebuffer-ready");
+        }
+
+        if (root.transitionState === root.statePendingSwap) {
+            maybeStartPendingSwap("ready");
+        }
+
+        refreshWatchdog();
+    }
+
+    function armTransitionFinalize() {
+        transitionFinalizeTimer.interval = Math.max(1, root.safeCrossfadeDuration() + 20);
+        transitionFinalizeTimer.restart();
+    }
+
+    function beginVisualSwitch(incoming, outgoing) {
+        // Keep outgoing on top and fade it out. Incoming is already visible underneath.
+        outgoing.z = 2;
+        incoming.z = 1;
+        incoming.opacity = 1;
+        outgoing.opacity = 0;
+        root.primaryPlayer = (incoming === videoPlayer1);
+        armTransitionFinalize();
+    }
+
+    function isPendingFadeIncoming(target) {
+        return root.fadeVisualPending && ((target === videoPlayer1) === root.fadeIncomingIsPlayer1);
+    }
+
+    function startVisualFadeIfReady(reason) {
+        if (!root.fadeVisualPending) {
+            return;
+        }
+
+        const incoming = root.fadeIncomingIsPlayer1 ? videoPlayer1 : videoPlayer2;
+        const outgoing = root.fadeIncomingIsPlayer1 ? videoPlayer2 : videoPlayer1;
+        const resumed = incoming.position > (root.fadeResumeBaselinePosition + root.fadeResumeMinDeltaMs);
+        const timedOut = Date.now() >= root.fadeResumeDeadlineMs;
+        if (!resumed && !timedOut) {
+            return;
+        }
+
+        if (timedOut && !resumed) {
+            root.logDebug("transition", `fade-visual-timeout incoming=${incoming.objectName} baseline=${root.fadeResumeBaselinePosition} position=${incoming.position}`);
+        } else {
+            root.logDebug("transition", `fade-visual-ready incoming=${incoming.objectName} baseline=${root.fadeResumeBaselinePosition} position=${incoming.position} reason=${reason}`);
+        }
+
+        root.fadeVisualPending = false;
+        root.fadeResumeDeadlineMs = 0;
+        beginVisualSwitch(incoming, outgoing);
+
+        if (root.fadeAdvanceSourcePending) {
+            root.fadeAdvanceSourcePending = false;
+            root.logDebug("transition", "request setNextSource()");
+            setNextSource();
+        }
+
+        refreshWatchdog();
+    }
+
+    function startFade(incoming, outgoing, shouldAdvanceSource, reason) {
+        if (root.transitionState === root.stateFading) {
+            return;
+        }
+
+        root.pendingTargetFilename = "";
+        root.pendingAdvancePlaylist = false;
+        root.pendingSwitchStartMs = 0;
+        root.holdActiveTailFrame = false;
+        root.fadeVisualPending = false;
+        root.fadeAdvanceSourcePending = false;
+        root.fadeResumeDeadlineMs = 0;
+
+        clearPrebufferState(incoming, "fade-start");
+        if (incoming.seekable && incoming.mediaStatus === MediaPlayer.EndOfMedia) {
+            incoming.position = 0;
+        }
+        incoming.play();
+        setTransitionState(root.stateFading, reason);
+        root.logDebug("transition", `fade-start incoming=${incoming.objectName} outgoing=${outgoing.objectName} reason=${reason}`);
+
+        // Keep outgoing fully visible until incoming makes post-resume progress.
+        outgoing.z = 2;
+        incoming.z = 1;
+        incoming.opacity = 1;
+        outgoing.opacity = 1;
+
+        root.fadeIncomingIsPlayer1 = (incoming === videoPlayer1);
+        root.fadeResumeBaselinePosition = incoming.position;
+        root.fadeResumeDeadlineMs = Date.now() + root.fadeResumeTimeoutMs;
+        root.fadeAdvanceSourcePending = shouldAdvanceSource;
+        root.fadeVisualPending = true;
+        startVisualFadeIfReady("start");
+
+        refreshWatchdog();
+    }
+
+    function startPrebufferedFade(shouldAdvanceSource, reason) {
+        const incoming = root.otherPlayer;
+        const outgoing = root.player;
+        startFade(incoming, outgoing, shouldAdvanceSource, reason);
+    }
+
+    function startDirectFade(shouldAdvanceSource, reason) {
+        const incoming = root.otherPlayer;
+        const outgoing = root.player;
+
+        root.pendingTargetFilename = "";
+        root.pendingAdvancePlaylist = false;
+        root.pendingSwitchStartMs = 0;
+        root.holdActiveTailFrame = false;
+
+        if (shouldAdvanceSource) {
+            root.logDebug("transition", "request setNextSource() for direct path");
+            setNextSource();
+        }
+
+        clearPrebufferState(incoming, "direct-switch");
+        assignPlayerSource(incoming, root.currentSource, "direct-switch");
+        startFade(incoming, outgoing, false, reason);
+    }
+
+    function maybeStartPendingSwap(reason) {
+        if (root.transitionState !== root.statePendingSwap) {
+            return;
+        }
+        const targetFilename = root.pendingTargetFilename;
+        if (!targetFilename) {
+            return;
+        }
+        if (!isInactivePrebufferReadyFor(targetFilename)) {
+            return;
+        }
+
+        root.logDebug("transition", `pending-ready target=${root.shortFilename(targetFilename)} reason=${reason}`);
+        startPrebufferedFade(root.pendingAdvancePlaylist, `pending-ready-${reason}`);
+    }
+
+    function failPrebufferTarget(target, reason) {
+        const failedFilename = target.prebufferTargetFilename;
+        const retryLimit = root.retryLimitForReason(reason);
+        const canRetry = (target.prebufferRetryCount || 0) < retryLimit
+                && root.prebufferNextVideo
+                && root.transitionState !== root.stateFading
+                && !!failedFilename;
+
+        root.logDebug("prebuffer", `fail player=${target.objectName} target=${root.shortFilename(failedFilename)} reason=${reason} willRetry=${canRetry}`);
+
+        if (retryPrebufferTarget(target, reason)) {
+            return;
+        }
+        clearPrebufferState(target, reason);
+        target.pause();
+
+        if (failedFilename) {
+            root.lastFailedTargetFilename = failedFilename;
+        }
+
+        if (root.transitionState === root.statePendingSwap && failedFilename === root.pendingTargetFilename) {
+            cancelPendingSwap(reason, failedFilename);
+            return;
+        }
+
+        if (root.transitionState === root.statePrebuffering) {
+            setTransitionState(root.stateIdle, `prebuffer-failed-${reason}`);
+        }
+
+        if (failedFilename && root.prebufferNextVideo) {
+            requestNextCandidate(failedFilename);
+        }
+
+        refreshWatchdog();
+    }
+
+    function cancelPendingSwap(reason, failedFilename) {
+        if (root.transitionState !== root.statePendingSwap) {
+            return;
+        }
+
+        const inactive = root.otherPlayer;
+        const failed = failedFilename || root.pendingTargetFilename;
+
+        root.pendingTargetFilename = "";
+        root.pendingAdvancePlaylist = false;
+        root.pendingSwitchStartMs = 0;
+        setTransitionState(root.stateIdle, `pending-cancel-${reason}`);
+        root.fadeVisualPending = false;
+        root.fadeAdvanceSourcePending = false;
+        root.fadeResumeDeadlineMs = 0;
+        clearPrebufferState(inactive, `pending-cancel-${reason}`);
+        inactive.pause();
+        releaseTailHold(true);
+
+        if (failed) {
+            root.logDebug("prebuffer", `cancel target=${root.shortFilename(failed)} reason=${reason}`);
+            requestNextCandidate(failed);
+        }
+
+        refreshWatchdog();
+    }
+
+    function requestPrebufferedSwitch(reason) {
+        const targetFilename = root.sourceFilename(root.nextSource);
+        root.logDebug("transition", `request target=${root.shortFilename(targetFilename)} reason=${reason}`);
+
+        if (!targetFilename) {
+            root.logDebug("transition", "missing prebuffer target, fallback to direct switch");
+            if (root.multipleVideos) {
+                startDirectFade(true, "missing-prebuffer-target");
+            } else {
+                startDirectFade(false, "missing-prebuffer-target-single");
+            }
+            return;
+        }
+
+        if (targetFilename === root.lastFailedTargetFilename) {
+            root.logDebug("prebuffer", `skip known failed target=${root.shortFilename(targetFilename)}`);
+            requestNextCandidate(targetFilename);
+            return;
+        }
+
+        if (isInactivePrebufferReadyFor(targetFilename)) {
+            startPrebufferedFade(true, "ready-at-request");
+            return;
+        }
+
+        root.pendingTargetFilename = targetFilename;
+        root.pendingAdvancePlaylist = true;
+        root.pendingSwitchStartMs = Date.now();
+        root.holdActiveTailFrame = false;
+        setTransitionState(root.statePendingSwap, "waiting-ready");
+        root.logDebug("transition", `pending target=${root.shortFilename(targetFilename)}`);
+
+        startPrebufferForInactive("pending-switch");
+        holdActiveFrameIfNearTail(root.player);
+        refreshWatchdog();
+    }
+
+    function finalizeTransition() {
+        const active = root.player;
+        const inactive = root.otherPlayer;
+
+        inactive.pause();
+        active.z = 2;
+        inactive.z = 1;
+        active.opacity = 1;
+        inactive.opacity = 1;
+        root.holdActiveTailFrame = false;
+        root.fadeVisualPending = false;
+        root.fadeAdvanceSourcePending = false;
+        root.fadeResumeDeadlineMs = 0;
+
+        setTransitionState(root.stateIdle, "finalize");
+        root.logDebug("transition", `finalize active=${active.objectName}`);
+
+        if (!root.prebufferNextVideo) {
+            clearPrebufferState(inactive, "finalize-non-prebuffer");
+            assignPlayerSource(inactive, Utils.createVideo(""), "non-prebuffer-clear");
+        } else {
+            prebufferTimer.restart();
+        }
+
+        refreshWatchdog();
+    }
+
+    function handleMediaStatus(target) {
+        const active = (root.player === target);
+
+        if (active && target.mediaStatus === MediaPlayer.EndOfMedia) {
+            if (root.transitionState === root.statePendingSwap) {
+                holdActiveFrameIfNearTail(target);
+                return;
+            }
+            if (!root.crossfadeEnabled && root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                root.next(true);
+            }
+            return;
+        }
+
+        if (active && target.mediaStatus === MediaPlayer.LoadedMedia && target.seekable) {
+            if (root.restoreLastPosition && root.resumeLastVideo && root.lastVideoPosition < target.duration) {
+                target.position = root.lastVideoPosition;
+            }
+            root.restoreLastPosition = false;
+        }
+
+        if (!target.prebufferPending) {
+            return;
+        }
+
+        if (!ensurePrebufferEventCurrent(target, `media-status-${target.mediaStatus}`)) {
+            return;
+        }
+
+        if (target.mediaStatus === MediaPlayer.EndOfMedia) {
+            if (target.position > 0) {
+                markPrebufferReady(target, "end-of-media");
+            } else {
+                root.logDebug("prebuffer", `end-without-progress player=${target.objectName} target=${root.shortFilename(target.prebufferTargetFilename)}`);
+                failPrebufferTarget(target, "end-without-progress");
+            }
+            return;
+        }
+
+        if (target.mediaStatus === MediaPlayer.InvalidMedia || target.mediaStatus === MediaPlayer.NoMedia) {
+            root.logDebug("prebuffer", `invalid player=${target.objectName} target=${root.shortFilename(target.prebufferTargetFilename)}`);
+            failPrebufferTarget(target, "invalid-media");
+            return;
+        }
+
+        if ((target.mediaStatus === MediaPlayer.LoadedMedia || target.mediaStatus === MediaPlayer.BufferedMedia)
+                && !target.playing) {
+            // Keep warming playback until first frame progress is observed.
+            target.play();
+        }
+    }
+
+    function maybeTriggerTransitionFromPosition(activePlayer) {
+        if (root.transitionState === root.statePendingSwap || root.transitionState === root.stateFading) {
+            return;
+        }
+
+        if (root.crossfadeEnabled
+                && (activePlayer.position / activePlayer.playbackRate) > (activePlayer.actualDuration - root.crossfadeMinDurationCurrent)) {
+            if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
+                root.next(true);
+            } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Never) {
+                root.next(false);
+            }
+            return;
+        }
+
+        if (!root.crossfadeEnabled
+                && root.prebufferNextVideo
+                && root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow
+                && !root.currentSource.loop
+                && root.multipleVideos
+                && activePlayer.duration > 0
+                && activePlayer.position >= Math.max(0, activePlayer.duration - root.holdTailLeadMs)) {
+            root.next(true);
+        }
+    }
+
+    function handlePosition(target) {
+        const active = (root.player === target);
+
+        if (active) {
+            if (target === videoPlayer1) {
+                if (!root.restoreLastPosition) {
+                    root.lastVideoPosition = target.position;
+                }
+            } else {
+                root.lastVideoPosition = target.position;
+            }
+
+            maybeTriggerTransitionFromPosition(target);
+
+            if (root.transitionState === root.statePendingSwap) {
+                holdActiveFrameIfNearTail(target);
+            }
+            return;
+        }
+
+        if (root.transitionState === root.stateFading && root.isPendingFadeIncoming(target)) {
+            root.startVisualFadeIfReady("position-progress");
+        }
+
+        if (target.prebufferPending && target.position >= root.prebufferWarmupMinMs) {
+            markPrebufferReady(target, "position-progress");
+        }
+    }
+
+    function handleSourceChanged(target) {
+        if (!target.prebufferPending || !target.source) {
+            return;
+        }
+        if (!ensurePrebufferEventCurrent(target, "source-changed")) {
+            return;
+        }
+        if (!target.playing) {
+            root.logDebug("prebuffer", `source-changed warmup player=${target.objectName} target=${root.shortFilename(target.prebufferTargetFilename)}`);
+            target.play();
+        }
+    }
+
+    function next(switchSource, forceSwitch) {
+        if (root.transitionState === root.stateFading) {
+            return;
+        }
+
+        const shouldSwitchSource = (switchSource && !currentSource.loop) || forceSwitch;
+
+        if (!shouldSwitchSource) {
+            if (root.transitionState === root.statePendingSwap) {
+                return;
+            }
+            startDirectFade(false, "same-source");
+            return;
+        }
+
+        if (!root.prebufferNextVideo) {
+            if (root.transitionState === root.statePendingSwap) {
+                return;
+            }
+            startDirectFade(true, "direct-no-prebuffer");
+            return;
+        }
+
+        if (root.transitionState === root.statePendingSwap) {
+            root.logDebug("transition", "request ignored while pending");
+            return;
+        }
+
+        requestPrebufferedSwitch("next");
+    }
 
     PausableTimer {
         id: changeTimer
@@ -91,8 +834,60 @@ Item {
         }
         onIntervalChanged: {
             if (root.debugEnabled) {
-                console.log("Timer changed:", interval);
+                root.logDebug("timer", `change interval=${interval}`);
             }
+        }
+    }
+
+    Timer {
+        id: transitionFinalizeTimer
+        interval: 1
+        repeat: false
+        onTriggered: root.finalizeTransition()
+    }
+
+    Timer {
+        id: prebufferWatchdog
+        interval: 150
+        repeat: true
+        running: false
+        onTriggered: {
+            const inactive = videoPlayer1.prebufferPending ? videoPlayer1
+                    : (videoPlayer2.prebufferPending ? videoPlayer2 : root.otherPlayer);
+
+            if (inactive.prebufferPending && inactive.prebufferStartMs > 0) {
+                if (!root.ensurePrebufferEventCurrent(inactive, "watchdog")) {
+                    root.refreshWatchdog();
+                    return;
+                }
+                const elapsed = Date.now() - inactive.prebufferStartMs;
+                const timeoutBudget = root.prebufferStallTimeoutMs + (inactive.prebufferRetryCount || 0) * root.prebufferRetryExtraTimeoutMs;
+                if (elapsed >= timeoutBudget) {
+                    root.logDebug("prebuffer", `cancel timeout player=${inactive.objectName} target=${root.shortFilename(inactive.prebufferTargetFilename)} elapsed=${elapsed}ms budget=${timeoutBudget}`);
+                    root.failPrebufferTarget(inactive, "timeout");
+                    return;
+                }
+            }
+
+            if (root.transitionState === root.statePendingSwap) {
+                if (root.pendingSwitchStartMs <= 0) {
+                    root.pendingSwitchStartMs = Date.now();
+                }
+                root.maybeStartPendingSwap("watchdog");
+                root.holdActiveFrameIfNearTail(root.player);
+
+                const pendingElapsed = Date.now() - root.pendingSwitchStartMs;
+                if (pendingElapsed >= root.pendingSwitchTimeoutMs) {
+                    root.logDebug("transition", `pending-timeout elapsed=${pendingElapsed}ms target=${root.shortFilename(root.pendingTargetFilename)}`);
+                    root.cancelPendingSwap("timeout", root.pendingTargetFilename);
+                    return;
+                }
+            }
+            if (root.transitionState === root.stateFading && root.fadeVisualPending) {
+                root.startVisualFadeIfReady("watchdog");
+            }
+
+            root.refreshWatchdog();
         }
     }
 
@@ -100,8 +895,17 @@ Item {
         id: videoPlayer1
         objectName: "1"
         anchors.fill: parent
-        property var playerSource: root.currentSource
+
+        property var playerSource: Utils.createVideo("")
         property int actualDuration: duration / playbackRate
+        property bool prebufferPending: false
+        property bool prebufferReady: false
+        property string prebufferTargetFilename: ""
+        property int prebufferGeneration: 0
+        property real prebufferStartMs: 0
+        property int prebufferReadyPosition: 0
+        property int prebufferRetryCount: 0
+
         playbackRate: {
             if (root.useAlternativePlaybackRate) {
                 return playerSource.alternativePlaybackRate || root.alternativePlaybackRateGlobal;
@@ -110,12 +914,13 @@ Item {
         }
         source: playerSource.filename ?? ""
         volume: root.volume
-        muted: root.muted
+        muted: root.muted || !root.primaryPlayer
         z: 2
         opacity: 1
         fillMode: root.fillMode
         fillBlur: root.fillBlur
         fillBlurRadius: root.fillBlurRadius
+
         loops: {
             if (!root.multipleVideos || (root.currentSource.loop && !root.crossfadeEnabled))
                 return MediaPlayer.Infinite;
@@ -124,65 +929,20 @@ Item {
             else
                 return MediaPlayer.Infinite;
         }
-        onPositionChanged: {
-            if (!root.primaryPlayer) {
-                return;
-            }
-            if (!root.restoreLastPosition) {
-                root.lastVideoPosition = position;
-            }
 
-            if (root.crossfadeEnabled) {
-                if ((position / playbackRate) > (actualDuration - root.crossfadeMinDurationCurrent)) {
-                    if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
-                        root.next(true);
-                    } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Never) {
-                        root.next(false);
-                    }
-                }
-            }
-        }
-        onMediaStatusChanged: {
-            if (mediaStatus == MediaPlayer.EndOfMedia) {
-                if (root.crossfadeEnabled) {
-                    return;
-                } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
-                    root.next(true);
-                }
-            }
+        onPositionChanged: root.handlePosition(videoPlayer1)
+        onMediaStatusChanged: root.handleMediaStatus(videoPlayer1)
+        onSourceChanged: root.handleSourceChanged(videoPlayer1)
 
-            if (mediaStatus == MediaPlayer.LoadedMedia && seekable) {
-                if (root.restoreLastPosition && root.resumeLastVideo) {
-                    if (root.lastVideoPosition < duration) {
-                        console.error("RESTORE LAST POSITION:", root.lastVideoPosition);
-                        videoPlayer1.position = root.lastVideoPosition;
-                    }
-                }
-                root.restoreLastPosition = false;
-            }
-        }
         onLoopsChanged: {
-            if (primaryPlayer) {
-                // needed to correctly update player with new loops value
+            if (root.primaryPlayer) {
                 let pos = videoPlayer1.position;
                 videoPlayer1.stop();
                 videoPlayer1.play();
                 videoPlayer1.position = pos;
             }
         }
-        onPlayingChanged: {
-            if (playing) {
-                if (root.debugEnabled) {
-                    console.log("Player 1 playing");
-                }
-            }
-        }
-        onOpacityChanged: {
-            if (opacity === 0 || opacity === 1) {
-                // Reset other player source to empty to free resources
-                otherPlayer.playerSource = Utils.createVideo("");
-            }
-        }
+
         Behavior on opacity {
             NumberAnimation {
                 duration: root.crossfadeDuration
@@ -195,8 +955,17 @@ Item {
         id: videoPlayer2
         objectName: "2"
         anchors.fill: parent
+
         property var playerSource: Utils.createVideo("")
         property int actualDuration: duration / playbackRate
+        property bool prebufferPending: false
+        property bool prebufferReady: false
+        property string prebufferTargetFilename: ""
+        property int prebufferGeneration: 0
+        property real prebufferStartMs: 0
+        property int prebufferReadyPosition: 0
+        property int prebufferRetryCount: 0
+
         playbackRate: {
             if (root.useAlternativePlaybackRate) {
                 return playerSource.alternativePlaybackRate || root.alternativePlaybackRateGlobal;
@@ -205,11 +974,13 @@ Item {
         }
         source: playerSource.filename ?? ""
         volume: root.volume
-        muted: root.muted
+        muted: root.muted || root.primaryPlayer
         z: 1
+        opacity: 1
         fillMode: root.fillMode
         fillBlur: root.fillBlur
         fillBlurRadius: root.fillBlurRadius
+
         loops: {
             if (!root.multipleVideos || (root.currentSource.loop && !root.crossfadeEnabled))
                 return MediaPlayer.Infinite;
@@ -218,46 +989,107 @@ Item {
             else
                 return MediaPlayer.Infinite;
         }
-        onPositionChanged: {
-            if (root.primaryPlayer) {
-                return;
-            }
-            root.lastVideoPosition = position;
 
-            if (root.crossfadeEnabled) {
-                if ((position / playbackRate) > (actualDuration - root.crossfadeMinDurationCurrent)) {
-                    if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
-                        root.next(true);
-                    } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Never) {
-                        root.next(false);
-                    }
-                }
-            }
-        }
-        onMediaStatusChanged: {
-            if (mediaStatus == MediaPlayer.EndOfMedia) {
-                if (root.crossfadeEnabled) {
-                    return;
-                } else if (root.changeWallpaperMode === Enum.ChangeWallpaperMode.Slideshow) {
-                    root.next(true);
-                }
-            }
-        }
+        onPositionChanged: root.handlePosition(videoPlayer2)
+        onMediaStatusChanged: root.handleMediaStatus(videoPlayer2)
+        onSourceChanged: root.handleSourceChanged(videoPlayer2)
+
         onLoopsChanged: {
-            if (!primaryPlayer) {
-                // needed to correctly update player with new loops value
+            if (!root.primaryPlayer) {
                 let pos = videoPlayer2.position;
                 videoPlayer2.stop();
                 videoPlayer2.play();
                 videoPlayer2.position = pos;
             }
         }
-        onPlayingChanged: {
-            if (playing) {
-                if (root.debugEnabled) {
-                    console.log("Player 2 playing");
-                }
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: root.crossfadeDuration
+                easing.type: Easing.OutQuint
             }
         }
+    }
+
+    onNextSourceChanged: {
+        const nextFilename = root.sourceFilename(root.nextSource);
+
+        if (nextFilename !== root.lastFailedTargetFilename) {
+            root.lastFailedTargetFilename = "";
+        }
+
+        if (!root.prebufferNextVideo) {
+            return;
+        }
+
+        if (root.transitionState === root.statePendingSwap) {
+            if (nextFilename) {
+                root.pendingTargetFilename = nextFilename;
+                root.logDebug("transition", `pending target updated=${root.shortFilename(root.pendingTargetFilename)} from nextSource`);
+            } else {
+                root.logDebug("transition", "nextSource became empty while pending; keeping existing pending target");
+            }
+        }
+
+        if (!nextFilename) {
+            if (root.transitionState === root.statePrebuffering) {
+                setTransitionState(root.stateIdle, "nextSource-empty");
+            }
+            return;
+        }
+
+        startPrebufferForInactive("nextSource-changed");
+        maybeStartPendingSwap("nextSource-changed");
+    }
+
+    onCurrentSourceChanged: syncActivePlayerSource(false)
+
+    onPrimaryPlayerChanged: {
+        if (root.prebufferNextVideo && root.transitionState !== root.stateFading) {
+            prebufferTimer.restart();
+        }
+    }
+
+    Timer {
+        id: prebufferTimer
+        interval: 200
+        onTriggered: root.startPrebufferForInactive("timer")
+    }
+
+    Component.onCompleted: {
+        Qt.callLater(() => {
+            videoPlayer1.z = 2;
+            videoPlayer2.z = 1;
+            videoPlayer1.opacity = 1;
+            videoPlayer2.opacity = 1;
+            syncActivePlayerSource(true);
+            if (root.prebufferNextVideo) {
+                startPrebufferForInactive("component-init");
+            }
+        });
+    }
+
+    onPrebufferNextVideoChanged: {
+        if (root.prebufferNextVideo) {
+            root.logDebug("transition", "prebuffer enabled");
+            startPrebufferForInactive("prebuffer-enabled");
+            return;
+        }
+
+        root.logDebug("transition", "prebuffer disabled");
+        if (root.transitionState === root.statePendingSwap) {
+            cancelPendingSwap("prebuffer-disabled", "");
+        }
+
+        releaseTailHold(true);
+        setTransitionState(root.stateIdle, "prebuffer-disabled");
+
+        root.pendingTargetFilename = "";
+        root.pendingAdvancePlaylist = false;
+        clearPrebufferState(videoPlayer1, "prebuffer-disabled");
+        clearPrebufferState(videoPlayer2, "prebuffer-disabled");
+
+        assignPlayerSource(root.otherPlayer, Utils.createVideo(""), "non-prebuffer-clear");
+        refreshWatchdog();
     }
 }

--- a/package/contents/ui/code/enum.js
+++ b/package/contents/ui/code/enum.js
@@ -40,3 +40,14 @@ const MuteMode = {
   Never: 4,
   Always: 5,
 };
+
+const MediaStatus = {
+  NoMedia: 0,
+  LoadingMedia: 1,
+  LoadedMedia: 2,
+  StalledMedia: 3,
+  BufferingMedia: 4,
+  BufferedMedia: 5,
+  EndOfMedia: 6,
+  InvalidMedia: 7
+};

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -61,6 +61,7 @@ ColumnLayout {
     property alias cfg_BlurAnimationDuration: blurAnimationDurationSpinBox.value
     property alias cfg_CrossfadeEnabled: crossfadeEnabledCheckbox.checked
     property alias cfg_CrossfadeDuration: crossfadeDurationSpinBox.value
+    property alias cfg_PrebufferNextVideo: prebufferNextVideoCheckbox.checked
     property real cfg_PlaybackRate
     property real cfg_AlternativePlaybackRate
     property alias cfg_Volume: volumeSlider.value
@@ -560,6 +561,15 @@ ColumnLayout {
                 Kirigami.Theme.inherit: false
                 flat: true
             }
+        }
+
+        CheckBox {
+            id: prebufferNextVideoCheckbox
+            Kirigami.FormData.label: i18n("Preload next video:")
+            text: i18n("Minimize loading of a 2nd video")
+            visible: root.currentTab === 1
+            ToolTip.text: i18n("Loads a 2nd video into memory for an instant transition")
+            ToolTip.visible: hovered
         }
 
         CheckBox {


### PR DESCRIPTION
WIP of removing black-frame transitions between videos.

The current problem is: initially, both players start playing back a video. Desktop sees stream from player1 (it's opacity is 1 at the start). If player1 finishes its video while player2 is still playing, the transition will be instant (as expected). But this only happens because player2 simply plays behind player1. 

I need to investigate why a 2nd video is not paused at the beginning. My idea was to use a Timer to force loading and pausing a video, but that doesn't work yet correctly.

Relates to #208