### PR TITLE
feat: video decoding configuration

### DIFF
--- a/package/contents/ui/EnvironmentVariableModel.qml
+++ b/package/contents/ui/EnvironmentVariableModel.qml
@@ -1,0 +1,107 @@
+import QtQuick
+
+// import "code/utils.js" as Utils
+
+Item {
+    id: root
+    property ListModel model: ListModel {}
+    property bool isLoading: true
+    readonly property string plasmaEnvFile: "$HOME/.config/plasma-workspace/env/luisbocanegra.smart.video.wallpaper.reborn.sh"
+
+    signal updated
+    signal loaded
+
+    function initModel(envVars) {
+        model.clear();
+        let varList = envVars.split("\n");
+        for (let envVar of varList) {
+            let [name, value] = envVar.split("=");
+            const existsIndex = getIndex(name);
+            if (existsIndex !== -1) {
+                model.set(existsIndex, {
+                    name,
+                    value
+                });
+                continue;
+            }
+            model.append({
+                name,
+                value
+            });
+        }
+        root.isLoading = false;
+        loaded();
+    }
+
+    function getValue(name) {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            if (item.name === name) {
+                return item.value;
+            }
+        }
+        return "";
+    }
+
+    function getIndex(name) {
+        for (let i = 0; i < model.count; i++) {
+            const item = model.get(i);
+            if (item.name === name) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    function getPlasmaEnvVar(name, c) {
+        runCommand.exec(`grep 'export ${name}' "${plasmaEnvFile}" | sed 's/export ${name}=//'`, output => {
+            if (c) {
+                if (output.exitCode === 0 && output.stdout.length > 0) {
+                    return c(output.stdout.trim());
+                }
+                return c(null);
+            }
+        });
+    }
+
+    function setPlasmaEnvVar(name, value) {
+        // check if it exists
+        //   if it does replace
+        //   if it does not, append
+        runCommand.exec(`grep 'export ${name}' "${plasmaEnvFile}"`, output => {
+            if (output.exitCode === 0 && output.stdout.length > 0) {
+                console.log(`${name}`, output.stdout);
+                console.log(`sed -i 's/export ${name}=.*/export ${name}=${value}/g' "${plasmaEnvFile}"`);
+                runCommand.exec(`sed -i 's/export ${name}=.*/export ${name}=${value}/g' "${plasmaEnvFile}"`);
+            } else {
+                runCommand.exec(`touch "${plasmaEnvFile}" && echo "export ${name}=${value}" >> "${plasmaEnvFile}"`);
+            }
+        });
+    }
+
+    function removePlasmaEnvVar(name) {
+        console.log(`sed -i '/export ${name}=.*/d' "${plasmaEnvFile}"`);
+        runCommand.exec(`sed -i '/export ${name}=.*/d' "${plasmaEnvFile}"`);
+    }
+
+    function varExists(name) {
+        return getValue(name) !== "";
+    }
+
+    RunCommand {
+        id: runCommand
+    }
+
+    function getVars() {
+        let vars;
+        runCommand.exec(`printenv`, output => {
+            if (output.exitCode === 0 && output.stdout.length > 0) {
+                initModel(output.stdout.trim());
+            }
+        });
+    }
+
+    Component.onCompleted: {
+        getVars();
+    }
+}

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -81,6 +81,16 @@ ColumnLayout {
     property var isLockScreenSettings: null
     property int editingIndex: -1
     property var validDropExtensions: [".mp4", ".mpg", ".ogg", ".mov", ".webm", ".flv", ".mkv", ".avi", ".wmv", ".gif"]
+    property string qtMEdiaBackend
+    property string qtMEdiaBackendOverride
+    property string qtHwDecodingDevice
+    property string qtHwDecodingDeviceOverride
+
+    property string vaapiDriver
+    property string vaapiDriverOverride
+
+    property string vdpauDriver
+    property string vdpauDriverOverride
 
     property var muteModeModel: {
         // options for desktop and lock screen
@@ -220,6 +230,36 @@ ColumnLayout {
         }
     }
 
+    EnvironmentVariableModel {
+        id: envVarsModel
+        onLoaded: {
+            root.qtMEdiaBackend = getValue("QT_MEDIA_BACKEND");
+            root.qtHwDecodingDevice = getValue("QT_FFMPEG_DECODING_HW_DEVICE_TYPES");
+            root.vaapiDriver = getValue("LIBVA_DRIVER_NAME");
+            root.vdpauDriver = getValue("VDPAU_DRIVER");
+            getPlasmaEnvVar("QT_MEDIA_BACKEND", value => {
+                if (value !== null) {
+                    root.qtMEdiaBackendOverride = value;
+                }
+            });
+            getPlasmaEnvVar("QT_FFMPEG_DECODING_HW_DEVICE_TYPES", value => {
+                if (value !== null) {
+                    root.qtHwDecodingDeviceOverride = value;
+                }
+            });
+            getPlasmaEnvVar("LIBVA_DRIVER_NAME", value => {
+                if (value !== null) {
+                    root.vaapiDriverOverride = value;
+                }
+            });
+            getPlasmaEnvVar("VDPAU_DRIVER", value => {
+                if (value !== null) {
+                    root.vdpauDriverOverride = value;
+                }
+            });
+        }
+    }
+
     Component.onCompleted: {
         videosModel.initModel(cfg_VideoUrls);
         getAudioDevicesModel();
@@ -280,11 +320,26 @@ ColumnLayout {
                 checked: tabBar.currentIndex === 2
             },
             Kirigami.Action {
+                icon.name: "view-list-details"
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Advanced")
+                checked: tabBar.currentIndex === 3
+            },
+            Kirigami.Action {
                 icon.name: "emblem-favorite-symbolic"
                 text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Donate")
-                checked: tabBar.currentIndex === 3
+                checked: tabBar.currentIndex === 4
             }
         ]
+    }
+
+    Kirigami.Heading {
+        Layout.topMargin: Kirigami.Units.largeSpacing * 2
+        visible: root.currentTab === 3
+        text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Video Decoding")
+        font.weight: 600
+        Layout.alignment: Qt.AlignHCenter
+        horizontalAlignment: Text.AlignVCenter
+        level: 1
     }
 
     Kirigami.FormLayout {
@@ -888,13 +943,6 @@ ColumnLayout {
             }
         }
 
-        CheckBox {
-            id: debugEnabledCheckbox
-            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Enable debug:")
-            text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Print debug messages to the system log")
-            visible: root.currentTab === 1
-        }
-
         TextEdit {
             wrapMode: Text.Wrap
             Layout.maximumWidth: 400
@@ -984,6 +1032,207 @@ ColumnLayout {
             }
         }
 
+        ColumnLayout {
+            spacing: Kirigami.Units.largeSpacing
+            Label {
+                visible: root.currentTab === 3
+                text: "<strong>" + i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "A logout is needed for these settings to have an effect!") + "</strong>"
+                Layout.preferredWidth: 500
+                wrapMode: Label.WordWrap
+                color: Kirigami.Theme.neutralTextColor
+            }
+
+            Label {
+                visible: root.currentTab === 3
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "These settings are modified using <a href=\"%1\">Plasma Session Environment Variables</a>", "https://userbase.kde.org/Session_Environment_Variables")
+                Layout.preferredWidth: 500
+                wrapMode: Label.WordWrap
+                onLinkActivated: link => Qt.openUrlExternally(link)
+            }
+
+            Label {
+                visible: root.currentTab === 3
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "If after setting an option to default still shows a value it means you have configured an environment variable elsewhere! See <a href=\"%1\">Environment variables - ArchWiki</a>", "https://wiki.archlinux.org/title/Environment_variables")
+                Layout.preferredWidth: 500
+                wrapMode: Label.WordWrap
+                onLinkActivated: link => Qt.openUrlExternally(link)
+            }
+
+            Label {
+                visible: root.currentTab === 3
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Verify it's working, see <a href=\"%1\">Improve performance by enabling Hardware Video Acceleration</a>", "https://github.com/luisbocanegra/plasma-smart-video-wallpaper-reborn?tab=readme-ov-file#improve-performance-by-enabling-hardware-video-acceleration")
+                Layout.preferredWidth: 500
+                wrapMode: Label.WordWrap
+                onLinkActivated: link => Qt.openUrlExternally(link)
+            }
+
+            Label {
+                visible: root.currentTab === 3
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Looking for documentation?") + "<br>• <a href=\"https://doc.qt.io/qt-6/qtmultimedia-index.html\">Qt Multimedia</a><br>• <a href=\"https://doc.qt.io/qt-6/advanced-ffmpeg-configuration.html\">Qt Advanced FFmpeg Configuration</a><br>• <a href=\"https://wiki.archlinux.org/title/Hardware_video_acceleration\">Hardware video acceleration - ArchWiki</a>"
+                Layout.preferredWidth: 500
+                wrapMode: Label.WordWrap
+                onLinkActivated: link => Qt.openUrlExternally(link)
+            }
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Hardware acceleration backend:")
+            visible: root.currentTab === 3
+            ComboBox {
+                enabled: root.qtMEdiaBackendOverride !== "gstreamer"
+                model: [i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "System default"), "cuda", "drm", "dxva2", "d3d11va", "d3d12va", "opencl", "qsv", "vaapi", "vdpau", "videotoolbox", "mediacodec", "vulkan"]
+                onActivated: {
+                    if (currentIndex === 0) {
+                        envVarsModel.removePlasmaEnvVar("QT_FFMPEG_DECODING_HW_DEVICE_TYPES");
+                    } else {
+                        envVarsModel.setPlasmaEnvVar("QT_FFMPEG_DECODING_HW_DEVICE_TYPES", currentValue);
+                    }
+                }
+                currentIndex: root.qtHwDecodingDeviceOverride ? indexOfValue(root.qtHwDecodingDeviceOverride) : 0
+            }
+            Kirigami.ContextualHelpButton {
+                toolTipText: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "You can use this to force a specific gpu, for example by setting <strong>vaapi</strong> to use an integrated Intel/AMD gpu instead of a dedicated NVIDIA gpu, which uses <strong>cuda</strong>.<br><br>It's important to note that this will not work if both gpus use the same acceleration backend.")
+            }
+        }
+
+        Label {
+            visible: root.currentTab === 3
+            text: "QT_FFMPEG_DECODING_HW_DEVICE_TYPES<br>" + i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Current value:") + " <strong>" + (root.qtHwDecodingDevice || i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Qt default")) + "</strong>"
+            font.pointSize: Kirigami.Theme.smallFont.pointSize
+            color: Kirigami.Theme.disabledTextColor
+        }
+
+        ButtonGroup {
+            id: mediaBackendButtonGroup
+            onClicked: {
+                if (checkedButton) {
+                    root.qtMEdiaBackendOverride = checkedButton.backend;
+                    if (checkedButton.backend) {
+                        envVarsModel.setPlasmaEnvVar("QT_MEDIA_BACKEND", checkedButton.backend);
+                    } else {
+                        envVarsModel.removePlasmaEnvVar("QT_MEDIA_BACKEND");
+                    }
+                }
+            }
+        }
+        RowLayout {
+            // By default Qt will use the FFmpeg backend, if it causes playback issues in your system try switching to the GStreamer backend instead.
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Media backend:")
+            visible: root.currentTab === 3
+            RadioButton {
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "System default")
+                ButtonGroup.group: mediaBackendButtonGroup
+                property string backend: ""
+                checked: root.qtMEdiaBackendOverride === backend
+            }
+            Kirigami.ContextualHelpButton {
+                toolTipText: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "By default Qt will use the FFmpeg backend, if it causes playback issues in your system try switching to the GStreamer backend instead.<br><br>Make sure you have both backends installed in your system, on Arch the packages are <strong>qt6-multimedia-ffmpeg</strong> and <strong>qt6-multimedia-gstreamer</strong>")
+            }
+        }
+
+        RadioButton {
+            visible: root.currentTab === 3
+            text: "FFmpeg"
+            ButtonGroup.group: mediaBackendButtonGroup
+            property string backend: "ffmpeg"
+            checked: root.qtMEdiaBackendOverride === backend
+        }
+
+        RadioButton {
+            visible: root.currentTab === 3
+            text: "GStreamer"
+            ButtonGroup.group: mediaBackendButtonGroup
+            property string backend: "gstreamer"
+            checked: root.qtMEdiaBackendOverride === backend
+        }
+
+        Label {
+            visible: root.currentTab === 3
+            text: "QT_MEDIA_BACKEND<br>" + i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Current value:") + " <strong>" + (root.qtMEdiaBackend || i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Qt default")) + "</strong>"
+            font.pointSize: Kirigami.Theme.smallFont.pointSize
+            color: Kirigami.Theme.disabledTextColor
+        }
+
+        ////////////////
+        ComboBox {
+            visible: root.currentTab === 3
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "VA-API driver:")
+            model: [i18n("System default"), "i965", "iHD", "nouveau", "nvidia", "radeonsi"]
+            onActivated: {
+                if (currentIndex === 0) {
+                    envVarsModel.removePlasmaEnvVar("LIBVA_DRIVER_NAME");
+                } else {
+                    envVarsModel.setPlasmaEnvVar("LIBVA_DRIVER_NAME", currentValue);
+                }
+            }
+            currentIndex: root.vaapiDriverOverride ? indexOfValue(root.vaapiDriverOverride) : 0
+        }
+
+        Label {
+            visible: root.currentTab === 3
+            text: "LIBVA_DRIVER_NAME<br>" + i18n("Current value: ") + "<strong>" + (root.vaapiDriver || i18n("System default")) + "</strong>"
+            font.pointSize: Kirigami.Theme.smallFont.pointSize
+            color: Kirigami.Theme.disabledTextColor
+        }
+        ////////////////
+
+        ////////////////
+        ComboBox {
+            visible: root.currentTab === 3
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "VDPAU driver:")
+            model: [i18n("System default"), "va_gl", "nvidia"]
+            onActivated: {
+                if (currentIndex === 0) {
+                    envVarsModel.removePlasmaEnvVar("VDPAU_DRIVER");
+                } else {
+                    envVarsModel.setPlasmaEnvVar("VDPAU_DRIVER", currentValue);
+                }
+            }
+            currentIndex: root.vdpauDriverOverride ? indexOfValue(root.vdpauDriverOverride) : 0
+        }
+
+        Label {
+            visible: root.currentTab === 3
+            text: "VDPAU_DRIVER<br>" + i18n("Current value: ") + "<strong>" + (root.vdpauDriver || i18n("System default")) + "</strong>"
+            font.pointSize: Kirigami.Theme.smallFont.pointSize
+            color: Kirigami.Theme.disabledTextColor
+        }
+        ////////////////
+
+        Component.onCompleted: {
+            // align with parent form from wallpaper config page
+            if (typeof appearanceRoot !== "undefined") {
+                twinFormLayouts.push(appearanceRoot.parentLayout);
+            }
+
+            let candidate = root.parent;
+            while (candidate) {
+                if (candidate && candidate.hasOwnProperty("configDialog")) {
+                    root.isLockScreenSettings = candidate.configDialog.toString().includes("ScreenLockerKcm");
+                    break;
+                }
+                candidate = candidate.parent;
+            }
+        }
+    }
+
+    Kirigami.Heading {
+        Layout.topMargin: Kirigami.Units.largeSpacing * 2
+        visible: root.currentTab === 3
+        text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Debug")
+        font.weight: 600
+        Layout.alignment: Qt.AlignHCenter
+        horizontalAlignment: Text.AlignVCenter
+        level: 2
+    }
+
+    Kirigami.FormLayout {
+        CheckBox {
+            id: debugEnabledCheckbox
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Enable debug:")
+            text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Print debug messages to the system log")
+            visible: root.currentTab === 3
+        }
         Component.onCompleted: {
             // align with parent form from wallpaper config page
             if (typeof appearanceRoot !== "undefined") {
@@ -1002,7 +1251,7 @@ ColumnLayout {
     }
 
     Components.Donate {
-        visible: root.currentTab === 3
+        visible: root.currentTab === 4
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.margins: Kirigami.Units.gridUnit


### PR DESCRIPTION
Allows to set the following using Plasma's Session Environment Variables

QT_FFMPEG_DECODING_HW_DEVICE_TYPES
QT_MEDIA_BACKEND
LIBVA_DRIVER_NAME
VDPAU_DRIVER
QT_DISABLE_HW_TEXTURES_CONVERSION for https://github.com/luisbocanegra/plasma-smart-video-wallpaper-reborn/issues/104

<img width="1664" height="1308" alt="Screenshot_20260918_035231" src="https://github.com/user-attachments/assets/bd6f073d-ca5f-497e-a87c-4231e330d6ad" />

https://wiki.archlinux.org/title/Hardware_video_acceleration
https://doc.qt.io/qt-6/advanced-ffmpeg-configuration.html
https://doc.qt.io/qt-6/qtmultimedia-index.html
https://userbase.kde.org/Session_Environment_Variables
https://wiki.archlinux.org/title/Environment_variables
