### PR TITLE
Issue #252: [AI] Add a DPMS monitor listening for the Wayland signals and pause the video when a monitor goes into standby mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project("plasma-smart-video-wallpaper-reborn")
 option(INSTALL_WALLPAPER "Install wallpaper" ON)
 option(PACKAGE_WALLPAPER "Package wallpaper" OFF)
+option(BUILD_NATIVE_DPMS_MONITOR "Build the native KWin/Wayland DPMS monitor QML plugin" ON)
 
 set(PROJECT_DEP_VERSION "6.0.0")
 set(QT_MIN_VERSION "6.6.0")
@@ -29,6 +30,10 @@ if(INSTALL_WALLPAPER)
     find_package(Plasma ${PROJECT_DEP_VERSION} REQUIRED)
     plasma_install_package(package ${PLUGIN_ID} wallpapers)
     add_subdirectory(translate)
+endif()
+
+if(BUILD_NATIVE_DPMS_MONITOR)
+    add_subdirectory(package/contents/ui/dpms)
 endif()
 
 if(PACKAGE_WALLPAPER)

--- a/package/contents/ui/ScreenModel.qml
+++ b/package/contents/ui/ScreenModel.qml
@@ -27,6 +27,16 @@ Item {
     property bool screenStateCmdRunning: false
     property bool checkScreenState: false
     property string instanceId
+    // This screen's geometry, used to pick the matching output when the
+    // native DPMS monitor is available. See main.qml's `screenGeometry:
+    // main.parent?.screenGeometry ?? null` for the same pattern.
+    property var screenGeometry: null
+
+    property QtObject nativeDpms: null
+    // False on X11, non-KWin compositors, or when the native plugin isn't
+    // installed (e.g. installed from the KDE Store, which can only ship
+    // plain QML) - runScreenStateCmd()/screenTimer below cover those cases.
+    readonly property bool nativeDpmsAvailable: root.nativeDpms?.available ?? false
 
     RunCommand {
         id: runCommand
@@ -45,22 +55,69 @@ Item {
         instanceId: root.instanceId
     }
 
-    Timer {
-        id: screenTimer
-        running: root.checkScreenState
-        repeat: true
-        interval: 1000
-        onTriggered: {
-            if (root.checkScreenState && !root.screenStateCmdRunning) {
-                root.screenStateCmdRunning = true;
-                runCommand.exec(root.screenStateCmd, output => {
-                    root.screenStateCmdRunning = false;
-                    if (output.exitCode === 0 && output.stdout.length > 0) {
-                        const out = output.stdout.trim().toLowerCase();
-                        root.screenIsOff = out === "0" || out === "off";
-                    }
-                });
+    // Event-driven DPMS detection via the KWin/Wayland org_kde_kwin_dpms
+    // protocol (see package/contents/ui/dpms) - pushed by the compositor
+    // instantly instead of polled. Loaded dynamically because the module is
+    // an optional native plugin that may not be installed; a failed import
+    // throws a catchable JS exception instead of a fatal QML load error.
+    function tryInitNativeDpms() {
+        if (root.nativeDpms) {
+            return;
+        }
+        try {
+            const obj = Qt.createQmlObject('import org.kde.smartvideowallpaper.dpms 1.0; DpmsMonitor {}', root, "nativeDpmsMonitor");
+            obj.screenGeometry = Qt.binding(() => root.screenGeometry ?? Qt.rect(0, 0, 0, 0));
+            root.nativeDpms = obj;
+        } catch (e) {
+            root.nativeDpms = null;
+        }
+    }
+
+    Connections {
+        target: root.nativeDpms
+        function onScreenIsOffChanged() {
+            if (root.nativeDpms.available) {
+                root.screenIsOff = root.nativeDpms.screenIsOff;
             }
         }
+        function onAvailableChanged() {
+            if (root.nativeDpms.available) {
+                root.screenIsOff = root.nativeDpms.screenIsOff;
+            }
+        }
+    }
+
+    onCheckScreenStateChanged: {
+        if (checkScreenState) {
+            tryInitNativeDpms();
+        }
+    }
+
+    Component.onCompleted: {
+        if (root.checkScreenState) {
+            tryInitNativeDpms();
+        }
+    }
+
+    function runScreenStateCmd() {
+        if (!root.checkScreenState || root.screenStateCmdRunning || root.nativeDpmsAvailable)
+            return;
+        root.screenStateCmdRunning = true;
+        runCommand.exec(root.screenStateCmd, output => {
+            root.screenStateCmdRunning = false;
+            if (output.exitCode === 0 && output.stdout.length > 0) {
+                const out = output.stdout.trim().toLowerCase();
+                root.screenIsOff = out === "0" || out === "off";
+            }
+        });
+    }
+
+    // Fallback for when the native monitor isn't available.
+    Timer {
+        id: screenTimer
+        running: root.checkScreenState && !root.nativeDpmsAvailable
+        repeat: true
+        interval: 1000
+        onTriggered: root.runScreenStateCmd()
     }
 }

--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -50,6 +50,10 @@ ColumnLayout {
     property alias cfg_ScreenOffPausesVideo: screenOffPausesVideoCheckbox.checked
     property alias cfg_ScreenStateCmd: screenStateCmdTextField.text
     property string cfg_ScreenStateCmdDefault
+    // True once the native KWin/Wayland DPMS plugin confirms it can watch
+    // this screen directly, so the manual command field can stay hidden.
+    property bool nativeDpmsAvailable: false
+    property QtObject nativeDpmsProbe: null
     property alias showWarningMessage: showWarning.checked
     property alias cfg_CheckWindowsActiveScreen: activeScreenOnlyCheckbx.checked
     property alias cfg_DebugEnabled: debugEnabledCheckbox.checked
@@ -220,9 +224,25 @@ ColumnLayout {
         }
     }
 
+    Connections {
+        target: root.nativeDpmsProbe
+        function onAvailableChanged() {
+            root.nativeDpmsAvailable = root.nativeDpmsProbe.available;
+        }
+    }
+
     Component.onCompleted: {
         videosModel.initModel(cfg_VideoUrls);
         getAudioDevicesModel();
+        // Optional native plugin (see package/contents/ui/dpms) - a failed
+        // import just leaves nativeDpmsAvailable false and the manual
+        // command field visible, same as ScreenModel.qml's fallback.
+        try {
+            root.nativeDpmsProbe = Qt.createQmlObject('import org.kde.smartvideowallpaper.dpms 1.0; DpmsMonitor {}', root, "nativeDpmsProbe");
+            root.nativeDpmsAvailable = true;
+        } catch (e) {
+            root.nativeDpmsProbe = null;
+        }
     }
 
     Kirigami.FormLayout {
@@ -836,7 +856,7 @@ ColumnLayout {
 
         RowLayout {
             Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Screen state command:")
-            visible: screenOffPausesVideoCheckbox.checked && root.currentTab === 1
+            visible: screenOffPausesVideoCheckbox.checked && root.currentTab === 1 && !root.nativeDpmsAvailable
             TextField {
                 id: screenStateCmdTextField
                 placeholderText: root.cfg_ScreenStateCmdDefault
@@ -851,6 +871,15 @@ ColumnLayout {
                 flat: true
                 ToolTip.visible: hovered
                 display: AbstractButton.IconOnly
+            }
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Screen state detection:")
+            visible: screenOffPausesVideoCheckbox.checked && root.currentTab === 1 && root.nativeDpmsAvailable
+            Label {
+                text: i18nd("plasma_wallpaper_luisbocanegra.smart.video.wallpaper.reborn", "Using KWin's DPMS signal directly (instant, no command needed)")
+                opacity: 0.7
             }
         }
 

--- a/package/contents/ui/dpms/CMakeLists.txt
+++ b/package/contents/ui/dpms/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Native KWin/Wayland DPMS monitor QML plugin.
+#
+# An independent, system-wide QML module (org.kde.smartvideowallpaper.dpms),
+# installed to KDE_INSTALL_QMLDIR - the same standard location QtQuick,
+# org.kde.kirigami etc. live in - so ScreenModel.qml/config.qml can just
+# `import org.kde.smartvideowallpaper.dpms 1.0` normally. No custom import
+# path or relative-folder trickery needed.
+#
+# Optional: builds only when Qt6Qml and KWayland client dev headers are
+# present. Both call sites import it dynamically via Qt.createQmlObject in a
+# try/catch and fall back to command-polling when it can't be found, so this
+# is safe to skip - e.g. on the KDE Store's GHNS install, which can't ship a
+# compiled binary at all.
+find_package(Qt6 6.6 QUIET COMPONENTS Qml)
+find_package(KWayland QUIET)
+
+if(NOT Qt6Qml_FOUND OR NOT KWayland_FOUND)
+    message(STATUS "Qt6Qml or KWayland not found - skipping native DPMS monitor plugin (screen-off detection will fall back to polling)")
+    return()
+endif()
+
+include(ECMQmlModule)
+
+add_library(dpmsmonitorplugin)
+ecm_add_qml_module(dpmsmonitorplugin
+    URI "org.kde.smartvideowallpaper.dpms"
+    VERSION 1.0
+    GENERATE_PLUGIN_SOURCE
+)
+
+target_sources(dpmsmonitorplugin PRIVATE
+    dpmsmonitor.cpp
+    dpmsmonitor.h
+)
+target_link_libraries(dpmsmonitorplugin PRIVATE Qt6::Qml Plasma::KWaylandClient)
+
+ecm_finalize_qml_module(dpmsmonitorplugin DESTINATION ${KDE_INSTALL_QMLDIR})
+
+# ecm_finalize_qml_module's auto-computed INSTALL_RPATH for the generated
+# plugin target is off by one directory level here (verified: it resolves to
+# .../qt6/lib/x86_64-linux-gnu instead of .../lib/x86_64-linux-gnu, so the
+# plugin can't find the backing dpmsmonitorplugin library it links against).
+# Compute and set the correct $ORIGIN-relative path ourselves instead of
+# relying on it.
+file(RELATIVE_PATH dpms_plugin_rpath
+    "${CMAKE_INSTALL_PREFIX}/${KDE_INSTALL_QMLDIR}/org/kde/smartvideowallpaper/dpms"
+    "${CMAKE_INSTALL_PREFIX}/${KDE_INSTALL_LIBDIR}"
+)
+set_target_properties(dpmsmonitorpluginplugin PROPERTIES
+    INSTALL_RPATH "$ORIGIN/${dpms_plugin_rpath}"
+)
+
+if(INSTALL_WALLPAPER)
+    install(TARGETS dpmsmonitorplugin ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+endif()

--- a/package/contents/ui/dpms/dpmsmonitor.cpp
+++ b/package/contents/ui/dpms/dpmsmonitor.cpp
@@ -1,0 +1,127 @@
+#include "dpmsmonitor.h"
+
+#include <KWayland/Client/connection_thread.h>
+#include <KWayland/Client/dpms.h>
+#include <KWayland/Client/output.h>
+#include <KWayland/Client/registry.h>
+
+using namespace KWayland::Client;
+
+DpmsMonitor::DpmsMonitor(QObject *parent)
+    : QObject(parent)
+{
+    // Reuses the QGuiApplication's existing Wayland connection (plasmashell is
+    // already a Wayland client) instead of opening a second socket connection.
+    // Returns null on non-Wayland platforms (e.g. X11).
+    auto connection = ConnectionThread::fromApplication(this);
+    if (!connection) {
+        return;
+    }
+
+    m_registry = new Registry(this);
+    m_registry->create(connection);
+    connect(m_registry, &Registry::interfacesAnnounced, this, &DpmsMonitor::handleInterfacesAnnounced);
+    m_registry->setup();
+}
+
+DpmsMonitor::~DpmsMonitor() = default;
+
+bool DpmsMonitor::isAvailable() const
+{
+    return m_available;
+}
+
+bool DpmsMonitor::screenIsOff() const
+{
+    return m_screenIsOff;
+}
+
+QRect DpmsMonitor::screenGeometry() const
+{
+    return m_screenGeometry;
+}
+
+void DpmsMonitor::setScreenGeometry(const QRect &geometry)
+{
+    if (m_screenGeometry == geometry) {
+        return;
+    }
+    m_screenGeometry = geometry;
+    Q_EMIT screenGeometryChanged();
+    updateActiveOutput();
+}
+
+void DpmsMonitor::handleInterfacesAnnounced()
+{
+    const auto dpmsInterfaces = m_registry->interfaces(Registry::Interface::Dpms);
+    const auto outputInterfaces = m_registry->interfaces(Registry::Interface::Output);
+
+    if (dpmsInterfaces.isEmpty() || outputInterfaces.isEmpty()) {
+        // Compositor isn't KWin, or doesn't advertise org_kde_kwin_dpms_manager.
+        return;
+    }
+
+    m_dpmsManager = m_registry->createDpmsManager(dpmsInterfaces.first().name, dpmsInterfaces.first().version, this);
+
+    for (const auto &outputInterface : outputInterfaces) {
+        auto output = m_registry->createOutput(outputInterface.name, outputInterface.version, this);
+        auto dpms = m_dpmsManager->getDpms(output, this);
+
+        m_outputs.append(output);
+        m_dpmsForOutput.insert(output, dpms);
+
+        // Output geometry (and dpms support/mode) arrive asynchronously after
+        // creation, so re-run matching whenever any of it changes.
+        connect(output, &Output::changed, this, &DpmsMonitor::updateActiveOutput);
+        connect(dpms, &Dpms::modeChanged, this, &DpmsMonitor::updateActiveOutput);
+        connect(dpms, &Dpms::supportedChanged, this, &DpmsMonitor::updateActiveOutput);
+    }
+
+    updateActiveOutput();
+}
+
+void DpmsMonitor::updateActiveOutput()
+{
+    Output *matched = nullptr;
+
+    if (m_outputs.size() == 1) {
+        matched = m_outputs.first();
+    } else if (!m_screenGeometry.isNull()) {
+        // Output::geometry() combines globalPosition() with the native/physical
+        // pixel size (from wl_output's mode event). On fractionally-scaled
+        // outputs (e.g. 1.15x) that size never matches Plasma's logical
+        // screenGeometry, since wl_output.scale is integer-only and can't
+        // represent the real factor. Position, unlike size, is reported by
+        // KWin in logical compositor space already, so it lines up with
+        // screenGeometry - match on that alone.
+        for (auto *output : std::as_const(m_outputs)) {
+            if (output->globalPosition() == m_screenGeometry.topLeft()) {
+                matched = output;
+                break;
+            }
+        }
+    }
+
+    m_activeDpms = matched ? m_dpmsForOutput.value(matched) : nullptr;
+
+    setAvailable(m_activeDpms && m_activeDpms->isSupported());
+    setScreenIsOff(m_available && m_activeDpms->mode() != Dpms::Mode::On);
+}
+
+void DpmsMonitor::setAvailable(bool available)
+{
+    if (m_available == available) {
+        return;
+    }
+    m_available = available;
+    Q_EMIT availableChanged();
+}
+
+void DpmsMonitor::setScreenIsOff(bool off)
+{
+    if (m_screenIsOff == off) {
+        return;
+    }
+    m_screenIsOff = off;
+    Q_EMIT screenIsOffChanged();
+}

--- a/package/contents/ui/dpms/dpmsmonitor.h
+++ b/package/contents/ui/dpms/dpmsmonitor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QHash>
+#include <QList>
+#include <QObject>
+#include <QRect>
+#include <qqmlintegration.h>
+
+namespace KWayland
+{
+namespace Client
+{
+class Registry;
+class DpmsManager;
+class Dpms;
+class Output;
+}
+}
+
+// Event-driven DPMS (monitor power) state via the KWin-only org_kde_kwin_dpms
+// Wayland protocol - the same source kscreen-doctor reads, but pushed instead
+// of polled. Only available under Plasma Wayland; `available` stays false
+// everywhere else (X11, other compositors, or if KWin doesn't advertise the
+// protocol), so callers must keep a fallback for those cases.
+class DpmsMonitor : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(bool available READ isAvailable NOTIFY availableChanged)
+    Q_PROPERTY(bool screenIsOff READ screenIsOff NOTIFY screenIsOffChanged)
+    Q_PROPERTY(QRect screenGeometry READ screenGeometry WRITE setScreenGeometry NOTIFY screenGeometryChanged)
+
+public:
+    explicit DpmsMonitor(QObject *parent = nullptr);
+    ~DpmsMonitor() override;
+
+    bool isAvailable() const;
+    bool screenIsOff() const;
+    QRect screenGeometry() const;
+    void setScreenGeometry(const QRect &geometry);
+
+Q_SIGNALS:
+    void availableChanged();
+    void screenIsOffChanged();
+    void screenGeometryChanged();
+
+private:
+    void handleInterfacesAnnounced();
+    void updateActiveOutput();
+    void setAvailable(bool available);
+    void setScreenIsOff(bool off);
+
+    KWayland::Client::Registry *m_registry = nullptr;
+    KWayland::Client::DpmsManager *m_dpmsManager = nullptr;
+    QList<KWayland::Client::Output *> m_outputs;
+    QHash<KWayland::Client::Output *, KWayland::Client::Dpms *> m_dpmsForOutput;
+    KWayland::Client::Dpms *m_activeDpms = nullptr;
+    QRect m_screenGeometry;
+    bool m_available = false;
+    bool m_screenIsOff = false;
+};

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -111,7 +111,7 @@ WallpaperItem {
     property bool batteryDisablesBlur: pauseBattery && main.configuration.BatteryDisablesBlur
 
     property bool screenIsOff: screenModel.screenIsOff
-    property bool isCurrentActivity: Plasmoid.activity === windowModel.currentActivity
+    property bool isCurrentActivity: main.lockScreenMode || Plasmoid.activity === windowModel.currentActivity
     property bool screenOffPausesVideo: main.configuration.ScreenOffPausesVideo
     property bool lockScreenMode: false
     property bool debugEnabled: main.configuration.DebugEnabled
@@ -252,6 +252,7 @@ WallpaperItem {
         checkScreenState: main.screenOffPausesVideo && screenStateCmd !== ""
         screenStateCmd: main.configuration.ScreenStateCmd
         instanceId: Plasmoid.id ?? ""
+        screenGeometry: main.parent?.screenGeometry ?? null
     }
 
     EffectsModel {


### PR DESCRIPTION
This patch adds a C++ plugin that listens for the KWin/Wayland DPMS signals and passes them on as a QML signal.  This means for Wayland systems, regardless of GPU vendor, the video will pause when the screen goes into standby.  No timer, no polling is needed.