### PR TITLE
fix: gdbus_get_signal.sh leaking tail processes on ScreenSaver signal

### DIFF
--- a/package/contents/ui/DBusSignalMonitor.qml
+++ b/package/contents/ui/DBusSignalMonitor.qml
@@ -30,7 +30,7 @@ Item {
     RunCommand {
         id: runCommand
         onExited: (cmd, exitCode, exitStatus, stdout, stderr) => {
-            if (exitCode !== 130) {
+            if (exitCode !== 0) {
                 console.error(cmd, exitCode, exitStatus, stdout, stderr);
                 return;
             }

--- a/package/contents/ui/tools/gdbus_get_signal.sh
+++ b/package/contents/ui/tools/gdbus_get_signal.sh
@@ -7,21 +7,15 @@ SERVICE=${2}
 INTERFACE=${3}
 DBUS_PATH=${4}
 METHOD=${5}
-TMPFILE=$(mktemp)
-gdbus monitor --"${BUS_TYPE}" --dest "${SERVICE}" >"$TMPFILE" &
-PID=$!
-exit_code=130
-tail -f "$TMPFILE" | while IFS= read -r line; do
+
+while IFS= read -r line; do
   if [[ "$line" == *"${INTERFACE}.${METHOD}"* ]] && [[ "$line" == *"${DBUS_PATH}"* ]]; then
     echo "$line"
-    kill "$PID"
-    break
+    exit 0
   fi
   if [[ "$line" == *"Error"* ]]; then
-    ((exit_code = 1))
-    kill "$PID"
-    break
+    exit 1
   fi
-done
-rm -f "$TMPFILE"
-exit "$exit_code"
+done < <(gdbus monitor --"${BUS_TYPE}" --dest "${SERVICE}")
+
+exit 1


### PR DESCRIPTION
Fixes #267.

Same root cause and fix as luisbocanegra/plasma-panel-colorizer@22073fa: the old 'tail -f \$TMPFILE' pipeline could hang on some 'tail' versions and never got cleaned up, leaking one orphaned 'tail' process per screen lock/unlock. This replaces it with process substitution directly on 'gdbus monitor' output, removing the temp file and the extra process entirely.

Also updated 'DBusSignalMonitor.qml' since the script now exits 0 on success instead of 130.

Tested locally: locked/unlocked repeatedly and confirmed no orphaned 'tail' processes accumulate anymore.